### PR TITLE
docs(verification): verify readiness-assessment — verified, score 24

### DIFF
--- a/verification/evidence/readiness-assessment.yaml
+++ b/verification/evidence/readiness-assessment.yaml
@@ -1,0 +1,107 @@
+pattern: Readiness Assessment
+slug: readiness-assessment
+verified: '2026-07-02'
+adoption_score: 24
+naming_alignment: weak
+terminology_variants:
+- term: Agent Readiness / Readiness Report
+  used_by: Factory.ai (product and docs)
+  url: https://factory.ai/product/agent-readiness
+- term: agent-ready codebase
+  used_by: Guillaume Moigneu (Upsun engineering blog); also Eno Reyes (Factory AI) at AI Engineer
+  url: https://developer.upsun.com/posts/ai/making-coding-agents-reliable
+- term: DORA AI Capabilities Model
+  used_by: DORA research team / Google Cloud
+  url: https://cloud.google.com/blog/products/ai-machine-learning/introducing-doras-inaugural-ai-capabilities-model
+- term: AI Readiness Assessment
+  used_by: Microsoft Learn (interactive organizational assessment)
+  url: https://learn.microsoft.com/en-us/assessments/94f1c697-9ba7-4d47-ad83-7c6bd94b1505/
+- term: AI Maturity Self-Assessment
+  used_by: Coder
+  url: https://coder.com/blog/what-100-engineering-teams-revealed-about-ai-maturity-and-what-to-do-about-it
+- term: AI Readiness checklist
+  used_by: Dominika Zając (practitioner, Medium/dev.to)
+  url: https://domizajac.medium.com/is-your-repo-ready-for-the-ai-agents-revolution-926e548da528
+- term: AI-Readiness Assessment for Software Development
+  used_by: sw-craftsmanship-dojo (open-source assessment based on DORA and Stanford SWEPR research, hosted at ai-readiness.dev)
+  url: https://github.com/sw-craftsmanship-dojo/sw-ai-readiness-assessment
+evidence:
+- tier: T1
+  match: aliased
+  mechanism_quote: Evaluates your codebase across 8 technical pillars and 5 maturity levels. Finds the environment
+    problems that defeat any agent and tells you what to fix first.
+  source: Factory.ai — Agent Readiness (product)
+  url: https://factory.ai/product/agent-readiness
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Factory ships a commercial 'Agent Readiness' product that evaluates a codebase across 8 technical pillars
+    (Style & Validation, Build System, Testing, Documentation, Dev Environment, Observability, Security, Task Discovery)
+    and 5 maturity levels, producing a Readiness Report runnable today via app.factory.ai, a /readiness-report CLI
+    command, and CI integration (undated page; date = retrieval date)
+- tier: T1
+  match: aliased
+  mechanism_quote: Evaluate how ready your codebase is for autonomous AI coding agents like **Claude Code**, **Cursor**,
+    **GitHub Copilot**, and **Codex**. 39 automated checks, 7 pillars, 10+ languages.
+  source: Kodus — @kodus/agent-readiness (open-source CLI, npm)
+  url: https://github.com/kodustech/agent-readiness
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Open-source npm CLI (created 2026-02-02, 64 stars; date = repo last-updated per GitHub API) that runs 39
+    automated checks across 7 pillars (Style & Linting, Testing, Documentation, Dev Environment, CI/CD, Code Health,
+    Security) and outputs a maturity level, per-pillar scores, and prioritized recommendations — positioned as the
+    open-source alternative to Factory.ai's Agent Readiness
+- tier: T1
+  match: named
+  source: Microsoft Learn — AI Readiness Assessment (interactive assessment)
+  url: https://learn.microsoft.com/en-us/assessments/94f1c697-9ba7-4d47-ad83-7c6bd94b1505/
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Microsoft hosts a runnable ~45-minute interactive 'AI Readiness Assessment' that scores an organization's
+    preparedness for AI adoption across seven pillars (Business Strategy, AI Governance & Security, Data Foundations,
+    AI Strategy & Experience, Organization & Culture, Infrastructure for AI, Model Management) and returns curated
+    guidance; organization-level AI adoption rather than codebase-specific (undated page; date = retrieval date)
+- tier: T3
+  match: aliased
+  mechanism_quote: 'In this talk, we''ll explore eight categories that determine whether your codebase is agent-ready:
+    from style validation and build systems to dev environments and observability.'
+  source: Eno Reyes (CTO, Factory AI) — 'Making Codebases Agent Ready', AI Engineer conference talk (recording on
+    AI Engineer YouTube channel)
+  url: https://www.youtube.com/watch?v=ShuJ_CN6zr4
+  date: '2025-12-22'
+  retrieved: '2026-07-02'
+  claim: 15-minute conference talk arguing the bottleneck for agent adoption is codebase 'agent readiness' rather
+    than model quality, and presenting a framework of eight scored categories teams use to assess repos and prioritize
+    remediation before scaling agent use; 52k+ views
+- tier: T4
+  match: aliased
+  mechanism_quote: Getting your codebase agent-ready requires systematic coverage across eight areas.
+  source: Upsun engineering blog — Guillaume Moigneu, 'Making coding agents (Claude Code, Codex, etc.) reliable'
+  url: https://developer.upsun.com/posts/ai/making-coding-agents-reliable
+  date: '2026-02-17'
+  retrieved: '2026-07-02'
+  claim: Practitioner post with an '8 pillars of verification' framework and an 80-criteria checklist (10 criteria
+    per pillar across testing, documentation, code quality, build systems, dev environments, observability, security,
+    standards) for auditing whether a codebase is agent-ready and finding the biggest gap
+- tier: T4
+  match: named
+  source: Dominika Zając — 'Is your repo ready for the AI Agents revolution? Checklist' (Medium; also mirrored on
+    dev.to)
+  url: https://domizajac.medium.com/is-your-repo-ready-for-the-ai-agents-revolution-926e548da528
+  date: '2026-01-18'
+  retrieved: '2026-07-02'
+  claim: Practitioner article presenting an 'AI Readiness checklist' for evaluating a repository before AI-agent
+    adoption across four sections — Repository Hygiene, Testing Safety Net, Grounding Documents, and MCP Integrations
+    — including concrete criteria like a single obvious command for start/test/lint
+- tier: T4
+  match: aliased
+  mechanism_quote: The goal was to give engineering leaders a concrete way to benchmark where they stand and plan
+    what comes next.
+  source: Coder engineering blog — Carly Stephens and Kodie Dower, 'What 100 Engineering Teams Revealed About AI
+    Maturity and What to Do About It'
+  url: https://coder.com/blog/what-100-engineering-teams-revealed-about-ai-maturity-and-what-to-do-about-it
+  date: '2026-04-20'
+  retrieved: '2026-07-02'
+  claim: Coder released an 'AI Maturity Self-Assessment' plus a five-stage framework for how engineering organizations
+    adopt agentic AI, based on assessment data from 100+ engineering teams, so leaders can benchmark current state
+    and plan adoption
+verdict: verified


### PR DESCRIPTION
## Evidence summary

**In plain terms**: this practice is demonstrably established in industry — 3 shipped tool(s) implement it; 1 conference talk(s)/paper(s) present it; 3 practitioner post(s) show working implementations. However, the industry mostly practices it under **other names**: *agent readiness* (Factory.ai, Kodus, AI Engineer talks).

| Field | Value |
|---|---|
| Verdict (computed) | **verified** |
| Adoption score (computed) | 24 — `24 = 3×T1 (15) + 1×T3 (3) + 3×T4 (6)` — out of a possible 45 (3 entries max per tier). |
| Naming alignment (computed) | weak |
| Search queries used | 9 / 12 |

### How to read these fields

**Adoption score** — weighted sum of evidence entries that survived independent verification (at most 3 count per tier):
shipped product/tool (T1) = 5 pts · official vendor docs (T2) = 4 · conference talk or peer-reviewed paper (T3) = 3 · practitioner blog with implementation detail (T4) = 2 · social/podcast mention (T5) = 1. Range 0–45.
Rough bands: **0–2** = no meaningful evidence · **3–7** = thin signal · **8+ with a T1–T3 anchor** = established practice, not just blog chatter.

**Verdict** — computed by `scripts/validate-evidence.py`, never asserted:
- **verified** = score ≥ 8 AND at least one T1–T3 entry (a runnable tool, canonical docs, or the conference/paper record — not just opinions).
- **weak** = evidence exists but is thin, or high volume built only on T4/T5 blogs and mentions.
- **unverified** = score ≤ 2 after all three search modes ran — the practice itself may not be established (triggers a human demotion discussion, never automatic removal).

**Naming alignment** — a separate question from the verdict: *does the industry call it what we call it?*
- **strong** = more than half of the evidence uses this catalog's pattern name.
- **weak** = the practice is real but most sources name it something else (see terminology variants).
- **none** = no source uses our name or a recognized alias.
`verified` + weak/none naming means "real practice, our name for it" — an alias/rename discussion, **not** an evidence problem.

**Search queries used** — each pattern is bounded to 12 queries across three modes (name, mechanism-with-name-excluded, artifact/code-fingerprint). A value under 12 means the search finished naturally; nothing was truncated by the cap.

### Accepted evidence (survived independent verify pass)

| Tier | Match | Source | Date |
|---|---|---|---|
| T1 | aliased | [Factory.ai — Agent Readiness (product)](https://factory.ai/product/agent-readiness) | 2026-07-02 |
| T1 | aliased | [Kodus — @kodus/agent-readiness (open-source CLI, npm)](https://github.com/kodustech/agent-readiness) | 2026-07-02 |
| T1 | named | [Microsoft Learn — AI Readiness Assessment (interactive assessment)](https://learn.microsoft.com/en-us/assessments/94f1c697-9ba7-4d47-ad83-7c6bd94b1505/) | 2026-07-02 |
| T3 | aliased | [Eno Reyes (CTO, Factory AI) — 'Making Codebases Agent Ready', AI Engineer conference talk (recording on AI Engineer YouTube channel)](https://www.youtube.com/watch?v=ShuJ_CN6zr4) | 2025-12-22 |
| T4 | aliased | [Upsun engineering blog — Guillaume Moigneu, 'Making coding agents (Claude Code, Codex, etc.) reliable'](https://developer.upsun.com/posts/ai/making-coding-agents-reliable) | 2026-02-17 |
| T4 | named | [Dominika Zając — 'Is your repo ready for the AI Agents revolution? Checklist' (Medium; also mirrored on dev.to)](https://domizajac.medium.com/is-your-repo-ready-for-the-ai-agents-revolution-926e548da528) | 2026-01-18 |
| T4 | aliased | [Coder engineering blog — Carly Stephens and Kodie Dower, 'What 100 Engineering Teams Revealed About AI Maturity and What to Do About It'](https://coder.com/blog/what-100-engineering-teams-revealed-about-ai-maturity-and-what-to-do-about-it) | 2026-04-20 |

### Terminology variants observed

- **Agent Readiness / Readiness Report** — used by Factory.ai (product and docs)
- **agent-ready codebase** — used by Guillaume Moigneu (Upsun engineering blog); also Eno Reyes (Factory AI) at AI Engineer
- **DORA AI Capabilities Model** — used by DORA research team / Google Cloud
- **AI Readiness Assessment** — used by Microsoft Learn (interactive organizational assessment)
- **AI Maturity Self-Assessment** — used by Coder
- **AI Readiness checklist** — used by Dominika Zając (practitioner, Medium/dev.to)
- **AI-Readiness Assessment for Software Development** — used by sw-craftsmanship-dojo (open-source assessment based on DORA and Stanford SWEPR research, hosted at ai-readiness.dev)

### Rejected by independent grader

- https://cloud.google.com/blog/products/ai-machine-learning/introducing-doras-inaugural-ai-capabilities-model — Tier failure: T2 requires canonical vendor docs and this is explicitly a Google Cloud *blog post* (the canonical artifact lives on dora.dev), and additionally the source presents a capabilities model — guidance on conditions that amplify AI benefits — not a readiness assessment mechanism producing a score and implementation plan, so the 'readiness rubric' framing is the collector's, not the source's.
- https://docs.aws.amazon.com/whitepapers/latest/aws-caf-for-ai/your-ai-transformation-journey.html — Aliased false analogy: the recorded quote is verbatim on the page, but the whitepaper addresses organizational AI/ML business transformation (business outcomes, AI flywheel, data strategy) — 'AI readiness' here means readiness to adopt AI technology in the enterprise, not codebase/team readiness for AI-assisted development — and the page is banner-flagged 'for historical reference only,' so it fails the same-problem test and is deprecated as current canonical guidance.

### Search coverage

Name mode found vendor-named readiness assessments (Microsoft interactive AI Readiness Assessment, AWS CAF-AI); mechanism mode (name excluded) surfaced the dominant industry alias 'agent readiness'/'agent-ready codebase' plus DORA's AI Capabilities Model and Coder's AI Maturity Self-Assessment; artifact mode (gh search repos) found Factory.ai's shipped Agent Readiness product, its open-source clone @kodus/agent-readiness, and an ecosystem of readiness-checker repos (forter/agentic-readiness-guide 103 stars, superduck-ai/agent-readiness, sw-craftsmanship-dojo), which led to the AI Engineer conference talk. Note the practice has bifurcated: org/team-level 'AI readiness' (Microsoft, AWS, DORA, Coder) vs codebase-level 'agent readiness' (Factory, Kodus, Upsun) — the catalog pattern spans both. GitHub's own Copilot rollout docs (docs.github.com, learn.github.com Well-Architected) cover launch planning/enablement but no pre-adoption assessment, so they were excluded; a circular LinkedIn post about this catalog itself was also excluded. Stopped at 9 of 12 queries with all tiers T1-T4 filled.

All three search modes ran (name, mechanism with pattern name excluded, artifact/code fingerprint). Every URL was fetched during this run by the collector and re-fetched by an independent grader (producer ≠ grader); score, verdict, and naming alignment are computed by `scripts/validate-evidence.py`, not asserted.

### Naming recommendation (pattern-spec checked)

**Recommendation: RENAME to "Agent Readiness"** — strong.

- **Dominant industry term**: *agent readiness*. Four of seven accepted sources use this exact root: Factory.ai ships a product literally named Agent Readiness (T1), Kodus's open-source CLI is `@kodus/agent-readiness` (T1), Eno Reyes's AI Engineer talk is "Making Codebases Agent Ready" (T3), and Upsun writes about the "agent-ready codebase" (T4).
- **Spec checklist on "Agent Readiness"**: two words Title Case ✓ · Noun+Noun ✓ · no "AI" prefix ✓ · domain-specific ✓ · 2–3 syllables/word ✓ · unique across catalog + experiments ✓ · "Use the Agent Readiness pattern to evaluate whether your codebase is ready for agents" ✓ · describes a principle, not one vendor's feature (two vendors + a talk use it) ✓.
- **Additional rationale**: the current name has a documented collision — name-mode searches for "readiness assessment" surface *organizational* AI-adoption readiness (Microsoft's assessment is org-level; the AWS CAF-AI candidate was rejected by the grader for exactly this false analogy). "Agent Readiness" disambiguates codebase-level readiness, which is what this pattern actually covers.

Renaming is a human decision; `PATTERN_MIGRATION_GUIDE.md` governs the mechanics if accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)