### PR TITLE
docs(verification): verify codified-rules — verified, score 25

### DIFF
--- a/verification/evidence/codified-rules.yaml
+++ b/verification/evidence/codified-rules.yaml
@@ -1,0 +1,109 @@
+pattern: Codified Rules
+slug: codified-rules
+verified: '2026-07-02'
+adoption_score: 25
+naming_alignment: weak
+terminology_variants:
+- term: AGENTS.md
+  used_by: OpenAI, Amp, Google Jules, Cursor, Factory; stewarded by the Agentic AI Foundation (Linux Foundation)
+  url: https://agents.md/
+- term: Rules / Project Rules / Team Rules
+  used_by: Cursor
+  url: https://cursor.com/docs/rules
+- term: CLAUDE.md / memory / .claude/rules/
+  used_by: Anthropic (Claude Code)
+  url: https://code.claude.com/docs/en/memory
+- term: repository custom instructions (copilot-instructions.md)
+  used_by: GitHub Copilot
+  url: https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions
+- term: custom instructions
+  used_by: 'OpenAI Codex (page title: "Custom instructions with AGENTS.md")'
+  url: https://developers.openai.com/codex/guides/agents-md
+- term: agent context files / Agent READMEs
+  used_by: Academic software-engineering research (Chatlatanagulchai et al., arXiv)
+  url: https://arxiv.org/abs/2511.12884
+- term: .cursorrules
+  used_by: Cursor community (PatrickJS/awesome-cursorrules)
+  url: https://github.com/PatrickJS/awesome-cursorrules
+evidence:
+- tier: T1
+  match: aliased
+  mechanism_quote: Project rules live in `.cursor/rules` as `.mdc` files and are version-controlled.
+  source: Cursor — Rules feature (official docs)
+  url: https://cursor.com/docs/rules
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Cursor ships a Rules feature where project rules live in .cursor/rules as version-controlled files scoped
+    by glob patterns, with User Rules, Team Rules enforced org-wide from a dashboard, and AGENTS.md as a plain-markdown
+    alternative; docs instruct users to check rules into git so the whole team benefits (undated page; date = retrieval
+    date)
+- tier: T1
+  match: aliased
+  mechanism_quote: Codex reads AGENTS.md files before doing any work. By layering global guidance with project-specific
+    overrides, you can start each task with consistent expectations, no matter which repository you open.
+  source: OpenAI — Codex AGENTS.md guide (shipped CLI/IDE/cloud agent behavior)
+  url: https://developers.openai.com/codex/guides/agents-md
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: OpenAI Codex, a shipped coding agent, reads layered AGENTS.md instruction files (global ~/.codex plus per-repository
+    and nested per-directory files) before doing any work, merging them root-down with closer files taking precedence
+    (undated page; date = retrieval date)
+- tier: T2
+  match: aliased
+  mechanism_quote: 'AGENTS.md complements this by containing the extra, sometimes detailed context coding agents
+    need: build steps, tests, and conventions that might clutter a README or aren’t relevant to human contributors.'
+  source: agents.md — AGENTS.md open format specification site (OpenAI, Amp, Google Jules, Cursor, Factory; stewarded
+    by the Agentic AI Foundation under the Linux Foundation)
+  url: https://agents.md/
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Canonical site for the AGENTS.md open format for repo-committed coding-agent instruction files (build steps,
+    code style, testing, security sections); states it is used by over 60k open-source projects and lists supporting
+    tools including Codex, Aider, Gemini CLI, Devin, Cursor, Windsurf, JetBrains Junie, VS Code, GitHub Copilot
+    coding agent, Google Jules, Zed, and Warp (undated page; date = retrieval date)
+- tier: T2
+  match: aliased
+  mechanism_quote: These instructions are shared with your team through version control, so focus on project-level
+    standards rather than personal preferences.
+  source: Anthropic — Claude Code docs, "How Claude remembers your project" (memory / CLAUDE.md)
+  url: https://code.claude.com/docs/en/memory
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Official Claude Code docs describe project CLAUDE.md files shared with the team through version control,
+    plus a .claude/rules/ directory of modular topic files (code-style.md, testing.md, security.md) with path-scoped
+    frontmatter — closely matching the pattern's .ai/rules/ structure; also documents managed org-wide CLAUDE.md
+    deployment (undated page; date = retrieval date)
+- tier: T2
+  match: aliased
+  mechanism_quote: These are specified in a `copilot-instructions.md` file in the `.github` directory of the repository.
+  source: GitHub — Copilot docs, "Adding repository custom instructions for GitHub Copilot"
+  url: https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Official GitHub docs define repository-wide custom instructions in .github/copilot-instructions.md, path-specific
+    NAME.instructions.md files with applyTo glob frontmatter, and AGENTS.md/CLAUDE.md/GEMINI.md agent instruction
+    files, all stored in the repository (undated page; date = retrieval date)
+- tier: T4
+  match: named
+  source: 'Nilo (AI Engineer, Google Cloud) — "SDLC Standards with Agentic Plugins: A Platform Engineer''s Field
+    Guide" (Google Cloud Community on Medium)'
+  url: https://medium.com/google-cloud/sdlc-standards-with-agentic-plugins-a-platform-engineers-field-guide-0c36f883b537
+  date: '2026-06-24'
+  retrieved: '2026-07-02'
+  claim: 'Practitioner guide showing org SDLC standards packaged as version-controlled rules/*.md files (with trigger:
+    always_on frontmatter, e.g. a secret-management rule) distributed to AI assistants via agentic plugins; the
+    conclusion states this facilitates ''how AI assistants adhere to standards in the organization with codified
+    rules'' — the only external source found using the pattern''s own phrase'
+- tier: T5
+  match: aliased
+  mechanism_quote: Already adopted by more than 20,000 repositories on GitHub, the format is being positioned as
+    a companion to traditional documentation, offering machine-readable context that complements human-facing files
+    like README.md.
+  source: Robert Krzaczyński — "AGENTS.md Emerges as Open Standard for AI Coding Agents" (InfoQ news)
+  url: https://www.infoq.com/news/2025/08/agents-md/
+  date: '2025-08-27'
+  retrieved: '2026-07-02'
+  claim: Dated, bylined industry news report that the AGENTS.md convention had already been adopted by more than
+    20,000 GitHub repositories at publication and is portable across Codex, Jules, Cursor, Aider, RooCode, and Zed;
+    includes practitioner skepticism from Hacker News
+verdict: verified


### PR DESCRIPTION
## Evidence summary

**In plain terms**: this practice is demonstrably established in industry — 2 shipped tool(s) implement it; 3 official vendor doc(s) prescribe it; 1 practitioner post(s) show working implementations; 1 dated public discussion(s) reference it. However, the industry mostly practices it under **other names**: `AGENTS.md`, *Rules* (Cursor), `CLAUDE.md` (Anthropic), *repository custom instructions* (GitHub).

| Field | Value |
|---|---|
| Verdict (computed) | **verified** |
| Adoption score (computed) | 25 — `25 = 2×T1 (10) + 3×T2 (12) + 1×T4 (2) + 1×T5 (1)` — out of a possible 45 (3 entries max per tier). |
| Naming alignment (computed) | weak |
| Search queries used | 7 / 12 |

### How to read these fields

**Adoption score** — weighted sum of evidence entries that survived independent verification (at most 3 count per tier):
shipped product/tool (T1) = 5 pts · official vendor docs (T2) = 4 · conference talk or peer-reviewed paper (T3) = 3 · practitioner blog with implementation detail (T4) = 2 · social/podcast mention (T5) = 1. Range 0–45.
Rough bands: **0–2** = no meaningful evidence · **3–7** = thin signal · **8+ with a T1–T3 anchor** = established practice, not just blog chatter.

**Verdict** — computed by `scripts/validate-evidence.py`, never asserted:
- **verified** = score ≥ 8 AND at least one T1–T3 entry (a runnable tool, canonical docs, or the conference/paper record — not just opinions).
- **weak** = evidence exists but is thin, or high volume built only on T4/T5 blogs and mentions.
- **unverified** = score ≤ 2 after all three search modes ran — the practice itself may not be established (triggers a human demotion discussion, never automatic removal).

**Naming alignment** — a separate question from the verdict: *does the industry call it what we call it?*
- **strong** = more than half of the evidence uses this catalog's pattern name.
- **weak** = the practice is real but most sources name it something else (see terminology variants).
- **none** = no source uses our name or a recognized alias.
`verified` + weak/none naming means "real practice, our name for it" — an alias/rename discussion, **not** an evidence problem.

**Search queries used** — each pattern is bounded to 12 queries across three modes (name, mechanism-with-name-excluded, artifact/code-fingerprint). A value under 12 means the search finished naturally; nothing was truncated by the cap.

### Accepted evidence (survived independent verify pass)

| Tier | Match | Source | Date |
|---|---|---|---|
| T1 | aliased | [Cursor — Rules feature (official docs)](https://cursor.com/docs/rules) | 2026-07-02 |
| T1 | aliased | [OpenAI — Codex AGENTS.md guide (shipped CLI/IDE/cloud agent behavior)](https://developers.openai.com/codex/guides/agents-md) | 2026-07-02 |
| T2 | aliased | [agents.md — AGENTS.md open format specification site (OpenAI, Amp, Google Jules, Cursor, Factory; stewarded by the Agentic AI Foundation under the Linux Foundation)](https://agents.md/) | 2026-07-02 |
| T2 | aliased | [Anthropic — Claude Code docs, "How Claude remembers your project" (memory / CLAUDE.md)](https://code.claude.com/docs/en/memory) | 2026-07-02 |
| T2 | aliased | [GitHub — Copilot docs, "Adding repository custom instructions for GitHub Copilot"](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions) | 2026-07-02 |
| T4 | named | [Nilo (AI Engineer, Google Cloud) — "SDLC Standards with Agentic Plugins: A Platform Engineer's Field Guide" (Google Cloud Community on Medium)](https://medium.com/google-cloud/sdlc-standards-with-agentic-plugins-a-platform-engineers-field-guide-0c36f883b537) | 2026-06-24 |
| T5 | aliased | [Robert Krzaczyński — "AGENTS.md Emerges as Open Standard for AI Coding Agents" (InfoQ news)](https://www.infoq.com/news/2025/08/agents-md/) | 2025-08-27 |

### Terminology variants observed

- **AGENTS.md** — used by OpenAI, Amp, Google Jules, Cursor, Factory; stewarded by the Agentic AI Foundation (Linux Foundation)
- **Rules / Project Rules / Team Rules** — used by Cursor
- **CLAUDE.md / memory / .claude/rules/** — used by Anthropic (Claude Code)
- **repository custom instructions (copilot-instructions.md)** — used by GitHub Copilot
- **custom instructions** — used by OpenAI Codex (page title: "Custom instructions with AGENTS.md")
- **agent context files / Agent READMEs** — used by Academic software-engineering research (Chatlatanagulchai et al., arXiv)
- **.cursorrules** — used by Cursor community (PatrickJS/awesome-cursorrules)

### Rejected by independent grader

- https://github.com/PatrickJS/awesome-cursorrules — Page is live, description quote and ~40.2k stars check out, but T1 fails its test: this is a community-curated collection of configuration file templates (an awesome-list), not a shipped product or tooling a user can run today — the claim itself frames it as 'community practice,' which is not T1 evidence.
- https://arxiv.org/abs/2511.12884 — Page is live and the study content (2,303 context files from 1,925 repos, evolve-like-configuration-code findings) matches the claim, but T3 fails its test: the arXiv page shows no comments field, conference acceptance, or peer-review venue, so the recorded 'peer-track SE paper' characterization is unsupported — it is a preprint.

### Search coverage

Name mode (2 queries): "Codified Rules" traces only to this catalog; "rules as code" is an unrelated legal/government term; one Google Cloud community post uses the phrase for the same mechanism (kept as the T4 named hit). Mechanism mode (3 queries incl. 1 research search) found the practice canonical at every major vendor under aliases (AGENTS.md, Rules, CLAUDE.md/memory, repository custom instructions) plus multiple arXiv studies. Artifact mode (2 GitHub code-search API queries): 135,648 files named AGENTS.md and 5,932 named .cursorrules on GitHub (retrieved 2026-07-02) — strong unnamed adoption evidence not listed as candidates because a count has no quotable sentence. Stopped at 7/12 queries with all tiers saturated; no conference-talk T3 was sought since the arXiv paper fills that tier.

All three search modes ran (name, mechanism with pattern name excluded, artifact/code fingerprint). Every URL was fetched during this run by the collector and re-fetched by an independent grader (producer ≠ grader); score, verdict, and naming alignment are computed by `scripts/validate-evidence.py`, not asserted.

### Naming recommendation (pattern-spec checked)

**Recommendation: KEEP + alias** (alias mentions added in #29).

- **Dominant industry term**: none dominates — the evidence splits across four vendor labels: `AGENTS.md` (open format), *Rules* (Cursor), `CLAUDE.md` memory (Anthropic), *repository custom instructions* (GitHub Copilot).
- **Candidates tested**: "Custom Instructions" (Adj+Noun ✓, unique ✓) fails the dominance bar — it is one vendor family's label, and it under-describes the mechanism (versioned, project-scoped config files). `AGENTS.md` is a filename, not a pattern name (fails Title Case two-word form). "Agent Rules" passes the checklist but no source uses it as a term, so it would trade our unused name for another unused name.
- **Why keep**: "Codified" is the load-bearing word — standards as versioned configuration rather than tribal knowledge — and no industry term captures that mechanism yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new verification reference document with structured rule metadata, naming variants, supporting evidence, and a final verified status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->