### PR TITLE
docs(verification): verify security-sandbox — verified, score 35

### DIFF
--- a/verification/evidence/security-sandbox.yaml
+++ b/verification/evidence/security-sandbox.yaml
@@ -1,0 +1,133 @@
+pattern: Security Sandbox
+slug: security-sandbox
+verified: '2026-07-02'
+adoption_score: 35
+naming_alignment: weak
+terminology_variants:
+- term: sandboxing / sandboxed Bash tool
+  used_by: Anthropic (Claude Code official docs)
+  url: https://code.claude.com/docs/en/sandboxing
+- term: sandbox (read-only / workspace-write / danger-full-access modes)
+  used_by: OpenAI (Codex official docs)
+  url: https://developers.openai.com/codex/concepts/sandboxing
+- term: dev container / devcontainer isolation
+  used_by: Anthropic docs and practitioners (Mark Phelps)
+  url: https://markphelps.me/posts/running-ai-agents-in-devcontainers/
+- term: execution isolation
+  used_by: Docker (company blog)
+  url: https://www.docker.com/blog/how-to-secure-ai-agents/
+- term: microVM sandbox
+  used_by: E2B (product site)
+  url: https://e2b.dev
+- term: agent sandbox / agent-sandbox
+  used_by: Kubernetes SIGs project
+  url: https://github.com/kubernetes-sigs/agent-sandbox
+- term: action-sandboxing
+  used_by: Beurer-Kellner et al. (arXiv design-patterns paper)
+  url: https://arxiv.org/html/2506.08837v2
+evidence:
+- tier: T1
+  match: named
+  source: Anthropic (anthropic-experimental), sandbox-runtime GitHub repository
+  url: https://github.com/anthropic-experimental/sandbox-runtime
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Anthropic ships an open-source sandboxing tool (4,557 stars, last updated 2026-07-02 per GitHub API) that
+    enforces filesystem and network restrictions on agent processes at the OS level; it is also installable as @anthropic-ai/sandbox-runtime
+    to back Claude Code's sandbox.
+- tier: T1
+  match: named
+  source: Kubernetes SIGs, agent-sandbox project
+  url: https://github.com/kubernetes-sigs/agent-sandbox
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: A Kubernetes SIG project (3,046 stars, created 2025-08-12, last updated 2026-07-02 per GitHub API) provides
+    isolated sandbox workloads for AI agent runtimes, showing the practice standardized at platform level under
+    the name 'agent-sandbox'.
+- tier: T1
+  match: named
+  source: E2B, product site
+  url: https://e2b.dev
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: E2B is a shipped commercial product providing Firecracker microVM sandboxes so AI agents can execute code
+    in full isolation from the host (undated page; date = retrieval date).
+- tier: T2
+  match: named
+  source: 'Anthropic, Claude Code docs: Configure the sandboxed Bash tool'
+  url: https://code.claude.com/docs/en/sandboxing
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Anthropic's official Claude Code documentation defines a built-in /sandbox capability with OS-enforced
+    filesystem and network isolation (Seatbelt on macOS, bubblewrap on Linux), including a sandbox.credentials setting
+    that denies reads of credential files like ~/.aws/credentials and unsets secret environment variables (undated
+    page; date = retrieval date).
+- tier: T2
+  match: named
+  source: 'OpenAI, Codex docs: Sandbox concepts page'
+  url: https://developers.openai.com/codex/concepts/sandboxing
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: OpenAI's official Codex documentation describes an OS-enforced sandbox (Seatbelt, bubblewrap, Windows Sandbox)
+    with network access disabled by default and read-only/workspace-write filesystem modes so the agent can act
+    autonomously without unrestricted machine access (undated page; date = retrieval date).
+- tier: T2
+  match: aliased
+  mechanism_quote: Avoid mounting host secrets such as `~/.ssh` or cloud credential files into the container; prefer
+    repository-scoped or short-lived tokens.
+  source: 'Anthropic, Claude Code docs: Development containers'
+  url: https://code.claude.com/docs/en/devcontainer
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Anthropic's official docs prescribe running Claude Code in a dev container with an init-firewall.sh egress
+    firewall and explicitly warn against mounting host secrets into the container — the same container-isolation-plus-no-secrets
+    mechanism as the pattern's Docker example (undated page; date = retrieval date). The referenced .devcontainer/
+    (Dockerfile, devcontainer.json, init-firewall.sh) was verified present in anthropics/claude-code via GitHub
+    API.
+- tier: T3
+  match: aliased
+  mechanism_quote: Any code execution must be sandboxed into its own environment with only necessary connections
+    allowed.
+  source: Luca Beurer-Kellner et al. (14 authors incl. Florian Tramèr, Edoardo Debenedetti), arXiv paper 'Design
+    Patterns for Securing LLM Agents against Prompt Injections' (arXiv:2506.08837)
+  url: https://arxiv.org/html/2506.08837v2
+  date: '2025-06-10'
+  retrieved: '2026-07-02'
+  claim: 'A multi-institution research paper (submitted 2025-06-10, v3 2025-06-27) codifies ''action-sandboxing''
+    as a design pattern: agent code execution must run in an isolated environment with only necessary connections
+    allowed.'
+- tier: T4
+  match: aliased
+  mechanism_quote: The agent runs in the container. It can’t touch your home directory, your SSH keys, or that one
+    file you really shouldn’t have left in `/tmp`.
+  source: Mark Phelps, blog post 'Running AI Agents in Devcontainers'
+  url: https://markphelps.me/posts/running-ai-agents-in-devcontainers/
+  date: '2026-02-19'
+  retrieved: '2026-07-02'
+  claim: Practitioner blog post (2026-02-19) shows complete .devcontainer/Dockerfile and devcontainer.json configurations
+    for running AI agents in containers isolated from the host home directory and SSH keys, calling the practice
+    'devcontainers'.
+- tier: T4
+  match: aliased
+  mechanism_quote: The goal isn't to eliminate risk entirely – it's to limit the blast radius. If something goes
+    wrong, we want it contained to the sandbox rather than having full access to your machine, credentials, and
+    the ability to push malicious code to your repositories.
+  source: Daniel Demmel, blog post 'Coding agents in secured VS Code dev containers'
+  url: https://www.danieldemmel.me/blog/coding-agents-in-secured-vscode-dev-containers
+  date: '2026-01-24'
+  retrieved: '2026-07-02'
+  claim: Practitioner blog post (2026-01-24) provides a complete working implementation (devcontainer.json, docker-compose.yml,
+    Dockerfile) for containing coding agents away from host credentials, framing it as 'secured dev containers'
+    that limit blast radius.
+- tier: T5
+  match: aliased
+  mechanism_quote: The most effective pattern is to run each agent in its own isolated, disposable environment.
+    This could be a microVM, a hardened container, or a dedicated sandbox.
+  source: 'Srini Sekaran (Docker), blog post ''How to Secure AI Agents: A Practical Overview'''
+  url: https://www.docker.com/blog/how-to-secure-ai-agents/
+  date: '2026-06-02'
+  retrieved: '2026-07-02'
+  claim: Docker company blog post (2026-06-02, named author, conceptual guidance without code) names 'execution
+    isolation' as one of four domains of agent security and recommends running each agent in an isolated, disposable
+    environment.
+verdict: verified


### PR DESCRIPTION
## Evidence summary

**In plain terms**: this practice is demonstrably established in industry — 3 shipped tool(s) implement it; 3 official vendor doc(s) prescribe it; 1 conference talk(s)/paper(s) present it; 2 practitioner post(s) show working implementations; 1 dated public discussion(s) reference it. However, the industry mostly practices it under **other names**: *sandboxing* — vendors use the same word, but split across sandbox/devcontainer/microVM framings.

| Field | Value |
|---|---|
| Verdict (computed) | **verified** |
| Adoption score (computed) | 35 — `35 = 3×T1 (15) + 3×T2 (12) + 1×T3 (3) + 2×T4 (4) + 1×T5 (1)` — out of a possible 45 (3 entries max per tier). |
| Naming alignment (computed) | weak |
| Search queries used | 10 / 12 |

### How to read these fields

**Adoption score** — weighted sum of evidence entries that survived independent verification (at most 3 count per tier):
shipped product/tool (T1) = 5 pts · official vendor docs (T2) = 4 · conference talk or peer-reviewed paper (T3) = 3 · practitioner blog with implementation detail (T4) = 2 · social/podcast mention (T5) = 1. Range 0–45.
Rough bands: **0–2** = no meaningful evidence · **3–7** = thin signal · **8+ with a T1–T3 anchor** = established practice, not just blog chatter.

**Verdict** — computed by `scripts/validate-evidence.py`, never asserted:
- **verified** = score ≥ 8 AND at least one T1–T3 entry (a runnable tool, canonical docs, or the conference/paper record — not just opinions).
- **weak** = evidence exists but is thin, or high volume built only on T4/T5 blogs and mentions.
- **unverified** = score ≤ 2 after all three search modes ran — the practice itself may not be established (triggers a human demotion discussion, never automatic removal).

**Naming alignment** — a separate question from the verdict: *does the industry call it what we call it?*
- **strong** = more than half of the evidence uses this catalog's pattern name.
- **weak** = the practice is real but most sources name it something else (see terminology variants).
- **none** = no source uses our name or a recognized alias.
`verified` + weak/none naming means "real practice, our name for it" — an alias/rename discussion, **not** an evidence problem.

**Search queries used** — each pattern is bounded to 12 queries across three modes (name, mechanism-with-name-excluded, artifact/code-fingerprint). A value under 12 means the search finished naturally; nothing was truncated by the cap.

### Accepted evidence (survived independent verify pass)

| Tier | Match | Source | Date |
|---|---|---|---|
| T1 | named | [Anthropic (anthropic-experimental), sandbox-runtime GitHub repository](https://github.com/anthropic-experimental/sandbox-runtime) | 2026-07-02 |
| T1 | named | [Kubernetes SIGs, agent-sandbox project](https://github.com/kubernetes-sigs/agent-sandbox) | 2026-07-02 |
| T1 | named | [E2B, product site](https://e2b.dev) | 2026-07-02 |
| T2 | named | [Anthropic, Claude Code docs: Configure the sandboxed Bash tool](https://code.claude.com/docs/en/sandboxing) | 2026-07-02 |
| T2 | named | [OpenAI, Codex docs: Sandbox concepts page](https://developers.openai.com/codex/concepts/sandboxing) | 2026-07-02 |
| T2 | aliased | [Anthropic, Claude Code docs: Development containers](https://code.claude.com/docs/en/devcontainer) | 2026-07-02 |
| T3 | aliased | [Luca Beurer-Kellner et al. (14 authors incl. Florian Tramèr, Edoardo Debenedetti), arXiv paper 'Design Patterns for Securing LLM Agents against Prompt Injections' (arXiv:2506.08837)](https://arxiv.org/html/2506.08837v2) | 2025-06-10 |
| T4 | aliased | [Mark Phelps, blog post 'Running AI Agents in Devcontainers'](https://markphelps.me/posts/running-ai-agents-in-devcontainers/) | 2026-02-19 |
| T4 | aliased | [Daniel Demmel, blog post 'Coding agents in secured VS Code dev containers'](https://www.danieldemmel.me/blog/coding-agents-in-secured-vscode-dev-containers) | 2026-01-24 |
| T5 | aliased | [Srini Sekaran (Docker), blog post 'How to Secure AI Agents: A Practical Overview'](https://www.docker.com/blog/how-to-secure-ai-agents/) | 2026-06-02 |

### Terminology variants observed

- **sandboxing / sandboxed Bash tool** — used by Anthropic (Claude Code official docs)
- **sandbox (read-only / workspace-write / danger-full-access modes)** — used by OpenAI (Codex official docs)
- **dev container / devcontainer isolation** — used by Anthropic docs and practitioners (Mark Phelps)
- **execution isolation** — used by Docker (company blog)
- **microVM sandbox** — used by E2B (product site)
- **agent sandbox / agent-sandbox** — used by Kubernetes SIGs project
- **action-sandboxing** — used by Beurer-Kellner et al. (arXiv design-patterns paper)

### Search coverage

Name mode found canonical vendor docs from both Anthropic and OpenAI using 'sandbox/sandboxing' for the exact mechanism (OS-enforced filesystem+network isolation, credential denial). Mechanism mode (name-varied queries on containers/credential-leak prevention) surfaced practitioner devcontainer implementations and Docker's 'execution isolation' framing; artifact mode found the pattern's config fingerprint in the wild (e.g. tsilva/agentbox using 'network_mode: none' with Claude) plus high-star shipped tooling (Anthropic sandbox-runtime 4.5k stars, kubernetes-sigs/agent-sandbox 3k stars). One conference-talk query returned nothing relevant, so T3 is covered by a verified arXiv paper instead; 10 of 12 query budget used.

All three search modes ran (name, mechanism with pattern name excluded, artifact/code fingerprint). Every URL was fetched during this run by the collector and re-fetched by an independent grader (producer ≠ grader); score, verdict, and naming alignment are computed by `scripts/validate-evidence.py`, not asserted.

### Naming recommendation (pattern-spec checked)

**Recommendation: KEEP** (optional alias: *agent sandbox*).

- **Dominant industry term**: *sandbox / sandboxing* — the same root as our name. Anthropic and OpenAI both use it canonically (Claude Code "Sandboxing" docs, Codex "Sandbox" concepts); 5 of 10 accepted entries are `named` matches (alignment computes `weak` only because 5/10 is not *more* than half).
- **Candidate tested**: "Agent Sandbox" (used verbatim by kubernetes-sigs/agent-sandbox, and E2B positions itself as sandboxes for agents) passes the full checklist, but the substance of the name already aligns — swapping the qualifier "Security" for "Agent" buys marginal recognition for real churn.
- **Why keep**: the pattern's name already contains the industry's word for the mechanism; the variance is in qualifiers and packaging (devcontainer, microVM), which belongs in `terminology_variants`, not the name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)