### PR TITLE
docs(verification): verify developer-lifecycle — verified, score 28

### DIFF
--- a/verification/evidence/developer-lifecycle.yaml
+++ b/verification/evidence/developer-lifecycle.yaml
@@ -1,0 +1,95 @@
+pattern: Developer Lifecycle
+slug: developer-lifecycle
+verified: '2026-07-02'
+adoption_score: 28
+naming_alignment: weak
+terminology_variants:
+- term: Spec-Driven Development
+  used_by: GitHub (Spec Kit) and Amazon Kiro
+  url: https://github.com/github/spec-kit
+- term: AI-DLC (AI-Driven Development Life Cycle)
+  used_by: AWS (DevOps blog methodology + awslabs/aidlc-workflows)
+  url: https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/
+- term: 'Explore, Plan, Code, Commit (docs heading: ''Explore first, then plan, then code''; feature: plan mode)'
+  used_by: Anthropic (Claude Code official docs)
+  url: https://code.claude.com/docs/en/best-practices
+- term: Specs / Three-Phase Workflow (Requirements -> Design -> Tasks)
+  used_by: AWS Kiro IDE
+  url: https://kiro.dev/docs/specs/
+evidence:
+- tier: T1
+  match: aliased
+  mechanism_quote: Use the **`/speckit.specify`** command to describe what you want to build. Focus on the **what**
+    and **why**, not the tech stack.
+  source: GitHub, Spec Kit (github/spec-kit repository)
+  url: https://github.com/github/spec-kit
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: 'GitHub ships Spec Kit (117,443 stars per GitHub API this run), an open-source toolkit whose staged slash-command
+    workflow (/speckit.constitution -> /speckit.specify -> /speckit.plan -> /speckit.tasks) takes a single feature
+    from problem description through governing principles, spec, and technical plan before any implementation. Repo
+    last-updated date shown by GitHub API: 2026-07-02.'
+- tier: T1
+  match: aliased
+  mechanism_quote: 'AI-DLC follows a structured three-phase approach that adapts to your project''s complexity:'
+  source: AWS Labs, aidlc-workflows repository
+  url: https://github.com/awslabs/aidlc-workflows
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: 'AWS Labs ships AI-DLC workflow steering rules (3,278 stars per GitHub API this run) installable into Kiro,
+    Amazon Q Developer, Cursor, Cline, Claude Code, GitHub Copilot, and OpenAI Codex, running features through Inception
+    (WHAT/WHY), Construction (HOW), and Operations phases. Repo last-updated date shown by GitHub API: 2026-07-02.'
+- tier: T1
+  match: aliased
+  mechanism_quote: 'All specs follow a three-phase workflow that transforms your idea into executable implementation:'
+  source: AWS Kiro IDE, Specs documentation
+  url: https://kiro.dev/docs/specs/
+  date: '2026-06-25'
+  retrieved: '2026-07-02'
+  claim: 'Kiro (AWS''s agentic IDE) ships a spec mode that generates requirements.md, design.md, and tasks.md per
+    feature and gates implementation behind a phased Requirements -> Design -> Tasks workflow with real-time task
+    tracking; page shows ''Page updated: June 25, 2026''.'
+- tier: T2
+  match: aliased
+  mechanism_quote: Letting Claude jump straight to coding can produce code that solves the wrong problem. Use plan
+    mode to separate exploration from execution.
+  source: Anthropic, Claude Code docs 'Best practices' (Explore first, then plan, then code)
+  url: https://code.claude.com/docs/en/best-practices
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Anthropic's canonical Claude Code docs prescribe a four-phase Explore -> Plan -> Implement -> Commit workflow
+    using plan mode to separate research/planning from code generation (undated page; date = retrieval date).
+- tier: T2
+  match: aliased
+  mechanism_quote: This pattern, where AI creates a plan, asks clarifying questions to seek context, and implements
+    solutions only after receiving human validation, repeats rapidly for every SDLC activity, to provide a unified
+    vision and approach for all development pathways.
+  source: 'AWS DevOps & Developer Productivity Blog, ''AI-Driven Development Life Cycle: Reimagining Software Engineering'''
+  url: https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/
+  date: '2025-07-31'
+  retrieved: '2026-07-02'
+  claim: AWS's official methodology announcement defines AI-DLC as a three-phase (Inception, Construction, Operations)
+    development lifecycle in which AI plans first and implements only after human validation, positioned as AWS's
+    reference approach for AI-assisted software delivery.
+- tier: T3
+  match: aliased
+  mechanism_quote: Spec-Driven Development allows for reproducible and reliable delivery, but spending time up-front
+    to improve the spec process will yield the best approach.
+  source: 'Al Harris (Principal Engineer, Amazon Kiro), ''Spec-Driven Development: Agentic Coding at FAANG Scale
+    and Quality'', AI Engineer conference talk (YouTube recording, 51,692 views)'
+  url: https://www.youtube.com/watch?v=HY_JyxAZsiE
+  date: '2026-01-09'
+  retrieved: '2026-07-02'
+  claim: A named Amazon principal engineer presents a 63-minute AI Engineer conference talk on running agentic coding
+    through an up-front spec/plan process rather than direct prompting-to-code; recording published 2026-01-09.
+- tier: T4
+  match: unnamed
+  mechanism_quote: Brainstorm spec, then plan a plan, then execute using LLM codegen. Discrete loops.
+  source: Harper Reed, 'My LLM codegen workflow atm' (harper.blog)
+  url: https://harper.blog/2025/02/16/my-llm-codegen-workflow-atm/
+  date: '2025-02-16'
+  retrieved: '2026-07-02'
+  claim: Practitioner post with full prompts and file conventions (spec.md, prompt_plan.md, todo.md) describing
+    a staged spec -> plan -> incremental execution workflow for building features with LLM codegen, explicitly crediting
+    the planning step with keeping projects under control.
+verdict: verified


### PR DESCRIPTION
## Evidence summary

**In plain terms**: this practice is demonstrably established in industry — 3 shipped tool(s) implement it; 2 official vendor doc(s) prescribe it; 1 conference talk(s)/paper(s) present it; 1 practitioner post(s) show working implementations. However, the industry mostly practices it under **other names**: *Spec-Driven Development* (GitHub), *AI-DLC* (AWS), and *plan mode* (Anthropic) — nobody uses our name.

| Field | Value |
|---|---|
| Verdict (computed) | **verified** |
| Adoption score (computed) | 28 — `28 = 3×T1 (15) + 2×T2 (8) + 1×T3 (3) + 1×T4 (2)` — out of a possible 45 (3 entries max per tier). |
| Naming alignment (computed) | weak |
| Search queries used | 10 / 12 |

### How to read these fields

**Adoption score** — weighted sum of evidence entries that survived independent verification (at most 3 count per tier):
shipped product/tool (T1) = 5 pts · official vendor docs (T2) = 4 · conference talk or peer-reviewed paper (T3) = 3 · practitioner blog with implementation detail (T4) = 2 · social/podcast mention (T5) = 1. Range 0–45.
Rough bands: **0–2** = no meaningful evidence · **3–7** = thin signal · **8+ with a T1–T3 anchor** = established practice, not just blog chatter.

**Verdict** — computed by `scripts/validate-evidence.py`, never asserted:
- **verified** = score ≥ 8 AND at least one T1–T3 entry (a runnable tool, canonical docs, or the conference/paper record — not just opinions).
- **weak** = evidence exists but is thin, or high volume built only on T4/T5 blogs and mentions.
- **unverified** = score ≤ 2 after all three search modes ran — the practice itself may not be established (triggers a human demotion discussion, never automatic removal).

**Naming alignment** — a separate question from the verdict: *does the industry call it what we call it?*
- **strong** = more than half of the evidence uses this catalog's pattern name.
- **weak** = the practice is real but most sources name it something else (see terminology variants).
- **none** = no source uses our name or a recognized alias.
`verified` + weak/none naming means "real practice, our name for it" — an alias/rename discussion, **not** an evidence problem.

**Search queries used** — each pattern is bounded to 12 queries across three modes (name, mechanism-with-name-excluded, artifact/code-fingerprint). A value under 12 means the search finished naturally; nothing was truncated by the cap.

### Accepted evidence (survived independent verify pass)

| Tier | Match | Source | Date |
|---|---|---|---|
| T1 | aliased | [GitHub, Spec Kit (github/spec-kit repository)](https://github.com/github/spec-kit) | 2026-07-02 |
| T1 | aliased | [AWS Labs, aidlc-workflows repository](https://github.com/awslabs/aidlc-workflows) | 2026-07-02 |
| T1 | aliased | [AWS Kiro IDE, Specs documentation](https://kiro.dev/docs/specs/) | 2026-06-25 |
| T2 | aliased | [Anthropic, Claude Code docs 'Best practices' (Explore first, then plan, then code)](https://code.claude.com/docs/en/best-practices) | 2026-07-02 |
| T2 | aliased | [AWS DevOps & Developer Productivity Blog, 'AI-Driven Development Life Cycle: Reimagining Software Engineering'](https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/) | 2025-07-31 |
| T3 | aliased | [Al Harris (Principal Engineer, Amazon Kiro), 'Spec-Driven Development: Agentic Coding at FAANG Scale and Quality', AI Engineer conference talk (YouTube recording, 51,692 views)](https://www.youtube.com/watch?v=HY_JyxAZsiE) | 2026-01-09 |
| T4 | unnamed | [Harper Reed, 'My LLM codegen workflow atm' (harper.blog)](https://harper.blog/2025/02/16/my-llm-codegen-workflow-atm/) | 2025-02-16 |

### Terminology variants observed

- **Spec-Driven Development** — used by GitHub (Spec Kit) and Amazon Kiro
- **AI-DLC (AI-Driven Development Life Cycle)** — used by AWS (DevOps blog methodology + awslabs/aidlc-workflows)
- **Explore, Plan, Code, Commit (docs heading: 'Explore first, then plan, then code'; feature: plan mode)** — used by Anthropic (Claude Code official docs)
- **Specs / Three-Phase Workflow (Requirements -> Design -> Tasks)** — used by AWS Kiro IDE

### Search coverage

Name mode found no industry use of "Developer Lifecycle" for this AI-assisted mechanism (generic "AI development lifecycle" hits were ML-model lifecycle content, a different practice); adoption is heavy but entirely under aliases: Spec-Driven Development (GitHub Spec Kit 117k stars, Kiro), AI-DLC (AWS), and Explore/Plan/Code/Commit + plan mode (Anthropic). Mechanism mode confirmed the requirements->design->tasks plan-first staging is mainstream, but the pattern's retry-limit sub-mechanism (Five-Try Rule) surfaced no independent adoption evidence within budget. Artifact mode: gh code search for "speckit.specify" returned ~10 distinct third-party repos (e.g., thunderbird/stormbox AGENTS.md, doggy8088/spec-kit, TortoiseWolfe/Claude_commands) embedding the staged commands, showing practice without the catalog's name; individual repos were not fetched/dated so they are noted here rather than listed as candidates.

All three search modes ran (name, mechanism with pattern name excluded, artifact/code fingerprint). Every URL was fetched during this run by the collector and re-fetched by an independent grader (producer ≠ grader); score, verdict, and naming alignment are computed by `scripts/validate-evidence.py`, not asserted.

### Naming recommendation (pattern-spec checked)

**Recommendation: KEEP, revisit after further evidence** — and note the SDD overlap.

- **Dominant industry term**: none for the full mechanism. Zero sources use "Developer Lifecycle"; adoption flows under *Spec-Driven Development* (GitHub Spec Kit), *AI-DLC* (AWS), and *plan mode / Explore-Plan-Code* (Anthropic).
- **Candidates tested, all fail**: "AI-DLC" fails the no-"AI"-prefix rule outright. "Spec-Driven Development" collides with an existing catalog pattern (uniqueness rule). "Plan Mode" maps to the planning stage only (Planned Implementation's territory), not the feature-to-production lifecycle.
- **Open question for a human**: the strongest evidence for this pattern (Spec Kit, Kiro) is the same evidence backing Spec-Driven Development — worth deciding whether this pattern's distinct value is the staged lifecycle framing, and whether the Lifecycle Lens already carries that. That is a scope question the pipeline can surface but not settle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)