### PR TITLE
docs(verification): verify tool-integration — verified, score 27

### DIFF
--- a/verification/evidence/tool-integration.yaml
+++ b/verification/evidence/tool-integration.yaml
@@ -1,0 +1,87 @@
+pattern: Tool Integration
+slug: tool-integration
+verified: '2026-07-02'
+adoption_score: 27
+naming_alignment: weak
+terminology_variants:
+- term: function calling / tool calling
+  used_by: OpenAI (API documentation)
+  url: https://developers.openai.com/api/docs/guides/function-calling
+- term: tool use
+  used_by: Anthropic (Claude API documentation)
+  url: https://platform.claude.com/docs/en/docs/build-with-claude/tool-use
+- term: Model Context Protocol (MCP)
+  used_by: Anthropic and the MCP open-source ecosystem
+  url: https://www.anthropic.com/news/model-context-protocol
+evidence:
+- tier: T1
+  match: aliased
+  mechanism_quote: The servers in this repository showcase the versatility and extensibility of MCP, demonstrating
+    how it can be used to give Large Language Models (LLMs) secure, controlled access to tools and data sources.
+  source: Model Context Protocol steering group, modelcontextprotocol/servers GitHub repository
+  url: https://github.com/modelcontextprotocol/servers
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Reference implementations of MCP servers (filesystem, fetch, etc.) with 87,974 stars, runnable today via
+    npx — including @modelcontextprotocol/server-filesystem, the exact package named in this pattern's own config
+    example (repo last updated 2026-07-02; created 2024-11-19)
+- tier: T1
+  match: aliased
+  mechanism_quote: Model Context Protocol (MCP) enables Cursor to connect to external tools and data sources.
+  source: Cursor, MCP documentation
+  url: https://cursor.com/docs/context/mcp
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Cursor ships built-in MCP support letting users connect the IDE's AI to external tools and data sources
+    today (undated page; date = retrieval date)
+- tier: T2
+  match: aliased
+  mechanism_quote: It provides a universal, open standard for connecting AI systems with data sources, replacing
+    fragmented integrations with a single protocol.
+  source: Anthropic, Model Context Protocol announcement
+  url: https://www.anthropic.com/news/model-context-protocol
+  date: '2024-11-25'
+  retrieved: '2026-07-02'
+  claim: 'Anthropic announced MCP as an open standard for exactly this pattern''s mechanism: standardized two-way
+    connections between AI systems and external data sources and tools'
+- tier: T2
+  match: aliased
+  mechanism_quote: Connect Claude to external tools and APIs.
+  source: Anthropic, Tool use with Claude documentation
+  url: https://platform.claude.com/docs/en/docs/build-with-claude/tool-use
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Anthropic's canonical API docs describe tool use as the mechanism for connecting Claude to user-defined
+    functions, external APIs, and MCP servers, with client-executed and server-executed tools (undated page; date
+    = retrieval date)
+- tier: T2
+  match: aliased
+  mechanism_quote: Function calling (also known as tool calling) provides a powerful and flexible way for OpenAI
+    models to interface with external systems and access data outside their training data.
+  source: OpenAI, Function calling guide (API documentation)
+  url: https://developers.openai.com/api/docs/guides/function-calling
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: OpenAI's canonical API docs describe function calling (also called tool calling) as the way models interface
+    with external systems and access data beyond training data (undated page; date = retrieval date)
+- tier: T3
+  match: aliased
+  mechanism_quote: we show that LMs can teach themselves to use external tools via simple APIs and achieve the best
+    of both worlds.
+  source: 'Schick et al. (Meta AI), Toolformer: Language Models Can Teach Themselves to Use Tools (arXiv 2302.04761)'
+  url: https://arxiv.org/abs/2302.04761
+  date: '2023-02-09'
+  retrieved: '2026-07-02'
+  claim: Research paper demonstrating language models learning to call external tools (calculator, search, QA, calendar)
+    via APIs to overcome limits of prompt-only generation
+- tier: T4
+  match: aliased
+  mechanism_quote: Function calling allows large language models (LLMs) to interact with external tools, APIs, and
+    functions based on user input.
+  source: Saurabh Rai (Apideck), An introduction to function calling and tool use
+  url: https://www.apideck.com/blog/llm-tool-use-and-function-calling
+  date: '2025-01-28'
+  retrieved: '2026-07-02'
+  claim: Practitioner blog with full working Python/Ollama implementation of tool definitions, orchestration loop,
+    and an external search-API tool (published 2025-01-28, page shows updated 2026-05-05)
+verdict: verified


### PR DESCRIPTION
## Evidence summary

**In plain terms**: this practice is demonstrably established in industry — 2 shipped tool(s) implement it; 3 official vendor doc(s) prescribe it; 1 conference talk(s)/paper(s) present it; 1 practitioner post(s) show working implementations. However, the industry mostly practices it under **other names**: *tool use* (Anthropic), *function calling* (OpenAI), *Model Context Protocol*.

| Field | Value |
|---|---|
| Verdict (computed) | **verified** |
| Adoption score (computed) | 27 — `27 = 2×T1 (10) + 3×T2 (12) + 1×T3 (3) + 1×T4 (2)` — out of a possible 45 (3 entries max per tier). |
| Naming alignment (computed) | weak |
| Search queries used | 5 / 12 |

### How to read these fields

**Adoption score** — weighted sum of evidence entries that survived independent verification (at most 3 count per tier):
shipped product/tool (T1) = 5 pts · official vendor docs (T2) = 4 · conference talk or peer-reviewed paper (T3) = 3 · practitioner blog with implementation detail (T4) = 2 · social/podcast mention (T5) = 1. Range 0–45.
Rough bands: **0–2** = no meaningful evidence · **3–7** = thin signal · **8+ with a T1–T3 anchor** = established practice, not just blog chatter.

**Verdict** — computed by `scripts/validate-evidence.py`, never asserted:
- **verified** = score ≥ 8 AND at least one T1–T3 entry (a runnable tool, canonical docs, or the conference/paper record — not just opinions).
- **weak** = evidence exists but is thin, or high volume built only on T4/T5 blogs and mentions.
- **unverified** = score ≤ 2 after all three search modes ran — the practice itself may not be established (triggers a human demotion discussion, never automatic removal).

**Naming alignment** — a separate question from the verdict: *does the industry call it what we call it?*
- **strong** = more than half of the evidence uses this catalog's pattern name.
- **weak** = the practice is real but most sources name it something else (see terminology variants).
- **none** = no source uses our name or a recognized alias.
`verified` + weak/none naming means "real practice, our name for it" — an alias/rename discussion, **not** an evidence problem.

**Search queries used** — each pattern is bounded to 12 queries across three modes (name, mechanism-with-name-excluded, artifact/code-fingerprint). A value under 12 means the search finished naturally; nothing was truncated by the cap.

### Accepted evidence (survived independent verify pass)

| Tier | Match | Source | Date |
|---|---|---|---|
| T1 | aliased | [Model Context Protocol steering group, modelcontextprotocol/servers GitHub repository](https://github.com/modelcontextprotocol/servers) | 2026-07-02 |
| T1 | aliased | [Cursor, MCP documentation](https://cursor.com/docs/context/mcp) | 2026-07-02 |
| T2 | aliased | [Anthropic, Model Context Protocol announcement](https://www.anthropic.com/news/model-context-protocol) | 2024-11-25 |
| T2 | aliased | [Anthropic, Tool use with Claude documentation](https://platform.claude.com/docs/en/docs/build-with-claude/tool-use) | 2026-07-02 |
| T2 | aliased | [OpenAI, Function calling guide (API documentation)](https://developers.openai.com/api/docs/guides/function-calling) | 2026-07-02 |
| T3 | aliased | [Schick et al. (Meta AI), Toolformer: Language Models Can Teach Themselves to Use Tools (arXiv 2302.04761)](https://arxiv.org/abs/2302.04761) | 2023-02-09 |
| T4 | aliased | [Saurabh Rai (Apideck), An introduction to function calling and tool use](https://www.apideck.com/blog/llm-tool-use-and-function-calling) | 2025-01-28 |

### Terminology variants observed

- **function calling / tool calling** — used by OpenAI (API documentation)
- **tool use** — used by Anthropic (Claude API documentation)
- **Model Context Protocol (MCP)** — used by Anthropic and the MCP open-source ecosystem

### Rejected by independent grader

- https://arxiv.org/abs/2508.02979 — Page is live and the quote is verbatim, but the claimed T3 tier fails its test: this is an arXiv preprint that is neither a conference talk nor a peer-reviewed paper (the evidence itself concedes 'preprint, not peer-reviewed'), so it cannot carry T3 weight.

### Search coverage

Name mode: 'tool integration' is used generically across MCP-era content and literally in one arXiv preprint title (named match); the dominant industry names are the aliases 'function calling' (OpenAI), 'tool use' (Anthropic), and MCP. Mechanism mode confirmed the practice is universal in vendor canonical docs and research (Toolformer); a third mechanism query on the pattern's security controls surfaced mostly agent-sandbox content, which belongs to the catalog's separate Security Sandbox pattern, so it was stopped there. Artifact mode: gh code search for the pattern's own config fingerprint '@modelcontextprotocol/server-filesystem' returned many independent public repos (ollama-mcp-bridge, daydreams, mcp-gateway, etc.), and the 87.9k-star modelcontextprotocol/servers repo ships that exact package — strong unnamed/aliased adoption evidence. 5 of 12 queries used; no candidates dropped for missing dates except undated T1/T2 pages handled per rule 2.

All three search modes ran (name, mechanism with pattern name excluded, artifact/code fingerprint). Every URL was fetched during this run by the collector and re-fetched by an independent grader (producer ≠ grader); score, verdict, and naming alignment are computed by `scripts/validate-evidence.py`, not asserted.

### Naming recommendation (pattern-spec checked)

**Recommendation: KEEP + alias** (alias mention added in #29).

- **Dominant industry terms**: *tool use* (Anthropic), *function calling* (OpenAI), *Model Context Protocol / MCP* — three coexisting vendor terms, no single dominant name.
- **Candidates tested**: "Tool Use" fails the naturalness test ("Use the Tool Use pattern to..." is unusable repetition). "Function Calling" passes the format checklist but names one vendor's API feature and is narrower than the pattern (which also covers MCP-style data-source integration). "MCP" is a protocol name, not a two-word pattern name.
- **Why keep**: "Tool Integration" already shares the industry's root word (*tool*) and is the only formulation broad enough to cover tool use + function calling + MCP without picking a vendor's flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)