### PR TITLE
docs(verification): verify issue-generation — verified, score 26

### DIFF
--- a/verification/evidence/issue-generation.yaml
+++ b/verification/evidence/issue-generation.yaml
@@ -1,0 +1,95 @@
+pattern: Issue Generation
+slug: issue-generation
+verified: '2026-07-02'
+adoption_score: 26
+naming_alignment: weak
+terminology_variants:
+- term: parse PRD / generate tasks (parse-prd)
+  used_by: Task Master (eyaltoledano/claude-task-master)
+  url: https://github.com/eyaltoledano/claude-task-master
+- term: Copilot issue generation
+  used_by: InfoQ (Steef-Jan Wiggers)
+  url: https://www.infoq.com/news/2026/02/ai-floods-close-projects/
+- term: create issues from a natural-language prompt
+  used_by: GitHub Docs (Copilot)
+  url: https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-to-create-issues
+- term: suggested child work items
+  used_by: Atlassian Support (Rovo / Atlassian Intelligence)
+  url: https://support.atlassian.com/organization-administration/docs/atlassian-intelligence-features-in-jira-software/
+- term: automated user story generation
+  used_by: Rahman & Zhu, arXiv GeneUS paper
+  url: https://arxiv.org/abs/2404.01558
+- term: graph issue tracker for AI agents
+  used_by: Beads (gastownhall/beads)
+  url: https://github.com/gastownhall/beads
+evidence:
+- tier: T1
+  match: aliased
+  mechanism_quote: The more detailed your PRD, the better the generated tasks will be.
+  source: Eyal Toledano - Task Master (eyaltoledano/claude-task-master)
+  url: https://github.com/eyaltoledano/claude-task-master
+  date: '2026-04-28'
+  retrieved: '2026-07-02'
+  claim: Shipped CLI/MCP tool (27,751 GitHub stars) whose parse-prd command generates a task list with dependencies
+    from a PRD for AI coding assistants (Cursor, Claude Code, Windsurf); README instructs users to parse requirements
+    and work tasks in dependency order.
+- tier: T1
+  match: aliased
+  mechanism_quote: It replaces messy markdown plans with a dependency-aware graph, allowing agents to handle long-horizon
+    tasks without losing context.
+  source: Steve Yegge / Gastown Hall - Beads (gastownhall/beads)
+  url: https://github.com/gastownhall/beads
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Shipped git-native 'distributed graph issue tracker for AI agents' (25,040 GitHub stars) providing agents
+    dependency-aware work items with epic hierarchies, blocker links, and ready-task detection.
+- tier: T1
+  match: unnamed
+  mechanism_quote: Analyzes your requirements document and generates a complete task breakdown.
+  source: vanzan01 - claude-code-sub-agent-collective (parse-prd command template)
+  url: https://github.com/vanzan01/claude-code-sub-agent-collective
+  date: '2026-04-20'
+  retrieved: '2026-07-02'
+  claim: Third-party Claude Code agent-collective repo (522 stars) ships a parse-prd command template that turns
+    a requirements document into a task breakdown with dependencies and testing tasks; GitHub code search also surfaced
+    other repos carrying .taskmaster/docs/prd.txt artifacts (e.g., wilplus/frontend-cursor).
+- tier: T2
+  match: aliased
+  mechanism_quote: Copilot can create or update issues from a natural-language prompt or a screenshot.
+  source: GitHub Docs - Using GitHub Copilot to create issues
+  url: https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-to-create-issues
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Official GitHub docs describe Copilot creating issues from a natural-language prompt, filling in title,
+    body, labels, and assignees using the repository's issue templates (undated page; date = retrieval date).
+- tier: T2
+  match: aliased
+  mechanism_quote: Generate a list of suggested child work items, based on the details of the parent work item.
+  source: Atlassian Support - Rovo AI features in Jira (Atlassian Intelligence)
+  url: https://support.atlassian.com/organization-administration/docs/atlassian-intelligence-features-in-jira-software/
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Official Atlassian docs describe an AI work-breakdown feature that generates suggested child work items
+    from a parent work item and links accepted suggestions as children, plus AI creation of work items from Slack/Teams/backlog
+    context (undated page; date = retrieval date).
+- tier: T4
+  match: aliased
+  mechanism_quote: 'And Claude executes the API calls: creates the Epic, then each Story with the Epic as parent,
+    with Acceptance Criteria in the description and estimates in the corresponding field.'
+  source: 'Nacho Bassino - ''PRD -> User Stories -> Jira: How to Automate the Full Pipeline with AI'' (Product Direction
+    Substack)'
+  url: https://productdirection.substack.com/p/prd-user-stories-jira-how-to-automate
+  date: '2026-01-27'
+  retrieved: '2026-07-02'
+  claim: Practitioner post with a reusable prompt template and Atlassian MCP configuration for converting a PRD
+    into an epic plus atomic user stories with Gherkin (Given/When/Then) acceptance criteria, created directly in
+    Jira with epic-child linking.
+- tier: T5
+  match: named
+  source: Steef-Jan Wiggers - InfoQ news, 'AI Vibe Coding Threatens Open Source as Maintainers Face Crisis'
+  url: https://www.infoq.com/news/2026/02/ai-floods-close-projects/
+  date: '2026-02-24'
+  retrieved: '2026-07-02'
+  claim: InfoQ news article refers to GitHub's shipped feature as 'Copilot issue generation' (launched May 2025)
+    while reporting that maintainers lack tools to filter the resulting AI-generated submissions.
+verdict: verified


### PR DESCRIPTION
## Evidence summary

**In plain terms**: this practice is demonstrably established in industry — 3 shipped tool(s) implement it; 2 official vendor doc(s) prescribe it; 1 practitioner post(s) show working implementations; 1 dated public discussion(s) reference it. However, the industry mostly practices it under **other names**: *Copilot issue generation* (GitHub), *parse-PRD / task generation* (Task Master, Rovo).

| Field | Value |
|---|---|
| Verdict (computed) | **verified** |
| Adoption score (computed) | 26 — `26 = 3×T1 (15) + 2×T2 (8) + 1×T4 (2) + 1×T5 (1)` — out of a possible 45 (3 entries max per tier). |
| Naming alignment (computed) | weak |
| Search queries used | 7 / 12 |

### How to read these fields

**Adoption score** — weighted sum of evidence entries that survived independent verification (at most 3 count per tier):
shipped product/tool (T1) = 5 pts · official vendor docs (T2) = 4 · conference talk or peer-reviewed paper (T3) = 3 · practitioner blog with implementation detail (T4) = 2 · social/podcast mention (T5) = 1. Range 0–45.
Rough bands: **0–2** = no meaningful evidence · **3–7** = thin signal · **8+ with a T1–T3 anchor** = established practice, not just blog chatter.

**Verdict** — computed by `scripts/validate-evidence.py`, never asserted:
- **verified** = score ≥ 8 AND at least one T1–T3 entry (a runnable tool, canonical docs, or the conference/paper record — not just opinions).
- **weak** = evidence exists but is thin, or high volume built only on T4/T5 blogs and mentions.
- **unverified** = score ≤ 2 after all three search modes ran — the practice itself may not be established (triggers a human demotion discussion, never automatic removal).

**Naming alignment** — a separate question from the verdict: *does the industry call it what we call it?*
- **strong** = more than half of the evidence uses this catalog's pattern name.
- **weak** = the practice is real but most sources name it something else (see terminology variants).
- **none** = no source uses our name or a recognized alias.
`verified` + weak/none naming means "real practice, our name for it" — an alias/rename discussion, **not** an evidence problem.

**Search queries used** — each pattern is bounded to 12 queries across three modes (name, mechanism-with-name-excluded, artifact/code-fingerprint). A value under 12 means the search finished naturally; nothing was truncated by the cap.

### Accepted evidence (survived independent verify pass)

| Tier | Match | Source | Date |
|---|---|---|---|
| T1 | aliased | [Eyal Toledano - Task Master (eyaltoledano/claude-task-master)](https://github.com/eyaltoledano/claude-task-master) | 2026-04-28 |
| T1 | aliased | [Steve Yegge / Gastown Hall - Beads (gastownhall/beads)](https://github.com/gastownhall/beads) | 2026-07-02 |
| T1 | unnamed | [vanzan01 - claude-code-sub-agent-collective (parse-prd command template)](https://github.com/vanzan01/claude-code-sub-agent-collective) | 2026-04-20 |
| T2 | aliased | [GitHub Docs - Using GitHub Copilot to create issues](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-to-create-issues) | 2026-07-02 |
| T2 | aliased | [Atlassian Support - Rovo AI features in Jira (Atlassian Intelligence)](https://support.atlassian.com/organization-administration/docs/atlassian-intelligence-features-in-jira-software/) | 2026-07-02 |
| T4 | aliased | [Nacho Bassino - 'PRD -> User Stories -> Jira: How to Automate the Full Pipeline with AI' (Product Direction Substack)](https://productdirection.substack.com/p/prd-user-stories-jira-how-to-automate) | 2026-01-27 |
| T5 | named | [Steef-Jan Wiggers - InfoQ news, 'AI Vibe Coding Threatens Open Source as Maintainers Face Crisis'](https://www.infoq.com/news/2026/02/ai-floods-close-projects/) | 2026-02-24 |

### Terminology variants observed

- **parse PRD / generate tasks (parse-prd)** — used by Task Master (eyaltoledano/claude-task-master)
- **Copilot issue generation** — used by InfoQ (Steef-Jan Wiggers)
- **create issues from a natural-language prompt** — used by GitHub Docs (Copilot)
- **suggested child work items** — used by Atlassian Support (Rovo / Atlassian Intelligence)
- **automated user story generation** — used by Rahman & Zhu, arXiv GeneUS paper
- **graph issue tracker for AI agents** — used by Beads (gastownhall/beads)

### Rejected by independent grader

- https://arxiv.org/abs/2404.01558 — Tier failure: this URL is an arXiv preprint with no journal reference or venue in its Comments field ('10 pages including 2 pages of Appendix'), so it fails the T3 peer-reviewed test even though the mechanism quote is verbatim in the abstract; a peer-reviewed successor exists as 'Take Loads Off Your Developers' at IEEE ICSME 2024 (ieeexplore.ieee.org/document/10795004) and should be cited instead.

### Search coverage

Name mode found the literal term mostly self-referential to this catalog, plus InfoQ independently using 'Copilot issue generation' for GitHub's shipped feature. Mechanism mode found strong vendor adoption (GitHub Copilot issue creation docs, Atlassian Rovo child-work-item generation), an arXiv paper (GeneUS), and a practitioner PRD-to-Jira pipeline post. Artifact mode (gh code search) confirmed high-star tooling (Task Master 27.7k, Beads 25k) and third-party repos embedding .taskmaster/prd.txt and parse-prd templates; stopped at 7 of 12 queries because all tiers were populated. Atlassian and GitHub docs pages are undated, so retrieval date was used per rules; a first Atlassian URL guess 404'd and was discarded.

All three search modes ran (name, mechanism with pattern name excluded, artifact/code fingerprint). Every URL was fetched during this run by the collector and re-fetched by an independent grader (producer ≠ grader); score, verdict, and naming alignment are computed by `scripts/validate-evidence.py`, not asserted.

### Naming recommendation (pattern-spec checked)

**Recommendation: KEEP.**

- **Dominant industry term**: none stable — GitHub docs say *create issues*, Task Master says *parse PRD / generate tasks*, Atlassian says *suggested child work items*. Notably, InfoQ independently used the phrase "Copilot issue generation" (the run's `named` T5 entry), so the current name is already how neutral third parties describe the practice.
- **Candidates tested**: "Task Generation" passes the format checklist but is no more industry-aligned than the current name (tool-specific parse-PRD jargon), and loses the tracker-native "issue" framing the T2 vendor docs use.
- **Why keep**: current name matches how independent coverage names the practice; no candidate improves alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)