### PR TITLE
docs(verification): verify spec-driven-development — verified, score 23

### DIFF
--- a/verification/evidence/spec-driven-development.yaml
+++ b/verification/evidence/spec-driven-development.yaml
@@ -1,0 +1,98 @@
+pattern: Spec-Driven Development
+slug: spec-driven-development
+verified: '2026-07-02'
+adoption_score: 23
+naming_alignment: strong
+terminology_variants:
+- term: intent-driven development
+  used_by: GitHub (spec-kit README)
+  url: https://github.com/github/spec-kit
+- term: spec-first / spec-anchored / spec-as-source
+  used_by: Birgitta Böckeler (Thoughtworks) on martinfowler.com
+  url: https://martinfowler.com/articles/exploring-gen-ai/sdd-3-tools.html
+- term: Structured-Prompt-Driven Development (SPDD)
+  used_by: Wei Zhang and Jessie Jie Xia on martinfowler.com
+  url: https://martinfowler.com/articles/structured-prompt-driven/
+- term: living specs
+  used_by: Augment Code
+  url: https://www.augmentcode.com/guides/living-specs-for-ai-agent-development
+- term: 'specs (Kiro product feature: requirements.md/design.md/tasks.md with EARS-notation acceptance criteria)'
+  used_by: AWS Kiro
+  url: https://kiro.dev/docs/specs/
+- term: executable specifications
+  used_by: Naman Jain, UC Berkeley EECS dissertation
+  url: https://www2.eecs.berkeley.edu/Pubs/TechRpts/2026/EECS-2026-158.html
+evidence:
+- tier: T1
+  match: named
+  source: GitHub, Spec Kit (github/spec-kit)
+  url: https://github.com/github/spec-kit
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: GitHub ships an open-source Spec-Driven Development toolkit (117k stars, 10.4k forks, 180 releases; latest
+    v0.12.4 dated 2026-07-02) with a constitution -> specify -> plan -> tasks -> implement workflow that works with
+    30+ AI coding agents, making specifications executable artifacts that drive implementation.
+- tier: T1
+  match: unnamed
+  mechanism_quote: This constitution supersedes other practices for architecture, quality, and workflow standards;
+    non-negotiable rules MUST be enforced during development and review.
+  source: OpenZeppelin, ui-builder repository (.specify/memory/constitution.md)
+  url: https://raw.githubusercontent.com/OpenZeppelin/ui-builder/main/.specify/memory/constitution.md
+  date: '2026-04-02'
+  retrieved: '2026-07-02'
+  claim: A shipped OpenZeppelin product maintains a versioned spec-kit constitution (v1.5.2, ratified 2025-09-17,
+    last amended 2026-04-02) whose machine-readable rules govern AI-assisted implementation and are enforced in
+    CI; GitHub code search shows the same .specify/memory/constitution.md fingerprint in repos from Microsoft, Cloud
+    Posse, Optimizely, and others, and the .kiro/specs/*/requirements.md fingerprint across dozens more unaffiliated
+    repos.
+- tier: T2
+  match: named
+  source: AWS Kiro, official Specs documentation
+  url: https://kiro.dev/docs/specs/
+  date: '2026-06-25'
+  retrieved: '2026-07-02'
+  claim: Kiro's canonical product docs define specs as structured artifacts (requirements.md with user stories and
+    acceptance criteria, design.md, tasks.md) that formalize development before AI implementation, with acceptance
+    criteria captured up front and progress tracked across discrete tasks.
+- tier: T3
+  match: aliased
+  mechanism_quote: 'Once these artifacts can be generated from problems, repositories, or executions, they make
+    behavior quantitatively measurable: agents can be evaluated by running candidate programs and comparing observed
+    behavior against specified behavior.'
+  source: Naman Jain, UC Berkeley EECS PhD dissertation 'Synthesizing Executable Specifications to Improve AI Programming
+    Agents' (EECS-2026-158)
+  url: https://www2.eecs.berkeley.edu/Pubs/TechRpts/2026/EECS-2026-158.html
+  date: '2026-05-15'
+  retrieved: '2026-07-02'
+  claim: A Berkeley dissertation studies synthesizing executable specifications (tests, performance harnesses, dynamic-analysis
+    annotations) as runnable artifacts that make AI agent output objectively verifiable against specified behavior.
+- tier: T4
+  match: named
+  source: 'Birgitta Böckeler (Thoughtworks), martinfowler.com ''Understanding Spec-Driven-Development: Kiro, spec-kit,
+    and Tessl'''
+  url: https://martinfowler.com/articles/exploring-gen-ai/sdd-3-tools.html
+  date: '2025-10-15'
+  retrieved: '2026-07-02'
+  claim: 'A hands-on comparison of three SDD tools (Kiro''s GIVEN/WHEN/THEN acceptance criteria in EARS-style requirements,
+    spec-kit''s constitution-driven workflow, Tessl''s regenerate-from-spec files marked ''GENERATED FROM SPEC -
+    DO NOT EDIT'') and a three-level taxonomy: spec-first, spec-anchored, spec-as-source.'
+- tier: T4
+  match: named
+  source: Augment Code, guide 'How to Write Living Specs for AI Agent Development'
+  url: https://www.augmentcode.com/guides/living-specs-for-ai-agent-development
+  date: '2026-06-18'
+  retrieved: '2026-07-02'
+  claim: A vendor implementation guide (published 2026-03-19, updated 2026-06-18) prescribing structured specs with
+    testable acceptance criteria (including EARS notation with human review gates) as coordination infrastructure
+    for AI agents, extending SDD with a 'living specs' feedback loop.
+- tier: T4
+  match: aliased
+  mechanism_quote: When reality diverges, fix the prompt first — then update the code.
+  source: Wei Zhang and Jessie Jie Xia, martinfowler.com 'Structured-Prompt-Driven Development (SPDD)'
+  url: https://martinfowler.com/articles/structured-prompt-driven/
+  date: '2026-04-28'
+  retrieved: '2026-07-02'
+  claim: An engineering method building on spec-driven development that treats structured prompts (a seven-part
+    REASONS Canvas covering requirements, entities, approach, structure, operations, norms, safeguards) as version-controlled
+    first-class delivery artifacts locked before AI code generation.
+verdict: verified


### PR DESCRIPTION
## Evidence summary

**In plain terms**: this practice is demonstrably established in industry — 2 shipped tool(s) implement it; 1 official vendor doc(s) prescribe it; 1 conference talk(s)/paper(s) present it; 3 practitioner post(s) show working implementations. The industry also uses **this pattern's own name** for it.

| Field | Value |
|---|---|
| Verdict (computed) | **verified** |
| Adoption score (computed) | 23 — `23 = 2×T1 (10) + 1×T2 (4) + 1×T3 (3) + 3×T4 (6)` — out of a possible 45 (3 entries max per tier). |
| Naming alignment (computed) | strong |
| Search queries used | 7 / 12 |

### How to read these fields

**Adoption score** — weighted sum of evidence entries that survived independent verification (at most 3 count per tier):
shipped product/tool (T1) = 5 pts · official vendor docs (T2) = 4 · conference talk or peer-reviewed paper (T3) = 3 · practitioner blog with implementation detail (T4) = 2 · social/podcast mention (T5) = 1. Range 0–45.
Rough bands: **0–2** = no meaningful evidence · **3–7** = thin signal · **8+ with a T1–T3 anchor** = established practice, not just blog chatter.

**Verdict** — computed by `scripts/validate-evidence.py`, never asserted:
- **verified** = score ≥ 8 AND at least one T1–T3 entry (a runnable tool, canonical docs, or the conference/paper record — not just opinions).
- **weak** = evidence exists but is thin, or high volume built only on T4/T5 blogs and mentions.
- **unverified** = score ≤ 2 after all three search modes ran — the practice itself may not be established (triggers a human demotion discussion, never automatic removal).

**Naming alignment** — a separate question from the verdict: *does the industry call it what we call it?*
- **strong** = more than half of the evidence uses this catalog's pattern name.
- **weak** = the practice is real but most sources name it something else (see terminology variants).
- **none** = no source uses our name or a recognized alias.
`verified` + weak/none naming means "real practice, our name for it" — an alias/rename discussion, **not** an evidence problem.

**Search queries used** — each pattern is bounded to 12 queries across three modes (name, mechanism-with-name-excluded, artifact/code-fingerprint). A value under 12 means the search finished naturally; nothing was truncated by the cap.

### Accepted evidence (survived independent verify pass)

| Tier | Match | Source | Date |
|---|---|---|---|
| T1 | named | [GitHub, Spec Kit (github/spec-kit)](https://github.com/github/spec-kit) | 2026-07-02 |
| T1 | unnamed | [OpenZeppelin, ui-builder repository (.specify/memory/constitution.md)](https://raw.githubusercontent.com/OpenZeppelin/ui-builder/main/.specify/memory/constitution.md) | 2026-04-02 |
| T2 | named | [AWS Kiro, official Specs documentation](https://kiro.dev/docs/specs/) | 2026-06-25 |
| T3 | aliased | [Naman Jain, UC Berkeley EECS PhD dissertation 'Synthesizing Executable Specifications to Improve AI Programming Agents' (EECS-2026-158)](https://www2.eecs.berkeley.edu/Pubs/TechRpts/2026/EECS-2026-158.html) | 2026-05-15 |
| T4 | named | [Birgitta Böckeler (Thoughtworks), martinfowler.com 'Understanding Spec-Driven-Development: Kiro, spec-kit, and Tessl'](https://martinfowler.com/articles/exploring-gen-ai/sdd-3-tools.html) | 2025-10-15 |
| T4 | named | [Augment Code, guide 'How to Write Living Specs for AI Agent Development'](https://www.augmentcode.com/guides/living-specs-for-ai-agent-development) | 2026-06-18 |
| T4 | aliased | [Wei Zhang and Jessie Jie Xia, martinfowler.com 'Structured-Prompt-Driven Development (SPDD)'](https://martinfowler.com/articles/structured-prompt-driven/) | 2026-04-28 |

### Terminology variants observed

- **intent-driven development** — used by GitHub (spec-kit README)
- **spec-first / spec-anchored / spec-as-source** — used by Birgitta Böckeler (Thoughtworks) on martinfowler.com
- **Structured-Prompt-Driven Development (SPDD)** — used by Wei Zhang and Jessie Jie Xia on martinfowler.com
- **living specs** — used by Augment Code
- **specs (Kiro product feature: requirements.md/design.md/tasks.md with EARS-notation acceptance criteria)** — used by AWS Kiro
- **executable specifications** — used by Naman Jain, UC Berkeley EECS dissertation

### Rejected by independent grader

- https://github.blog/ai-and-ml/generative-ai/spec-driven-development-with-ai-get-started-with-a-new-open-source-toolkit/ — Content and verbatim quote check out (Den Delimarsky, 2025-09-02), but the source is a github.blog blog post, which fails the T2 test's explicit 'canonical docs, not a blog' requirement — tier misclassification.
- https://arxiv.org/abs/2602.00180 — Page is live and the abstract contains the quoted sentence, but this is an arXiv preprint merely submitted to AIWare 2026 with no acceptance or peer review shown, so it fails T3's 'conference talk or peer-reviewed paper' test.

### Search coverage

Name mode: the exact term is now an industry-standard label used by GitHub (Spec Kit), AWS (Kiro), Tessl, martinfowler.com, and arXiv. Mechanism mode (name excluded) surfaced the same practice under EARS-notation requirements, living specs, plan-first, and executable-specification framings. Artifact mode: GitHub code search found spec-kit (.specify/memory/constitution.md) and Kiro (.kiro/specs/*/requirements.md) fingerprints in many unaffiliated repos including microsoft/Agent365-dotnet, OpenZeppelin/ui-builder, cloudposse/docs, and optimizely/optimizely-flutter-sdk. Used 7/12 queries; skipped T5 candidates (Reddit/YouTube hits lacked verifiable named-person+date without extra fetches) and did not separately fetch Tessl or Addy Osmani posts as evidence was already saturated at higher tiers.

All three search modes ran (name, mechanism with pattern name excluded, artifact/code fingerprint). Every URL was fetched during this run by the collector and re-fetched by an independent grader (producer ≠ grader); score, verdict, and naming alignment are computed by `scripts/validate-evidence.py`, not asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)