### PR TITLE
docs(verification): verify planned-implementation — verified, score 26

### DIFF
--- a/verification/evidence/planned-implementation.yaml
+++ b/verification/evidence/planned-implementation.yaml
@@ -1,0 +1,101 @@
+pattern: Planned Implementation
+slug: planned-implementation
+verified: '2026-07-02'
+adoption_score: 26
+naming_alignment: weak
+terminology_variants:
+- term: Plan Mode
+  used_by: Cursor (product feature) and Anthropic Claude Code (permission mode)
+  url: https://cursor.com/docs/agent/plan-mode
+- term: Explore first, then plan, then code (Explore, plan, code, commit)
+  used_by: Anthropic Claude Code best-practices docs
+  url: https://code.claude.com/docs/en/best-practices
+- term: Let Claude interview you
+  used_by: Anthropic Claude Code best-practices docs
+  url: https://code.claude.com/docs/en/best-practices
+- term: grill-me / clarify-first skill
+  used_by: Matt Pocock (skills.sh) and bswen.com practitioner writeup
+  url: https://skills.sh/mattpocock/skills/grill-me
+- term: intention clarification
+  used_by: Mu et al., ClarifyGPT (arXiv/ACM FSE)
+  url: https://arxiv.org/abs/2310.10996
+- term: brainstorm spec, then plan a plan, then execute
+  used_by: Harper Reed (harper.blog)
+  url: https://harper.blog/2025/02/16/my-llm-codegen-workflow-atm/
+evidence:
+- tier: T1
+  match: aliased
+  mechanism_quote: Plan Mode creates detailed implementation plans before writing any code. Agent researches your
+    codebase, asks clarifying questions, and generates a reviewable plan you can edit before building.
+  source: Cursor - Plan Mode documentation
+  url: https://cursor.com/docs/agent/plan-mode
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: 'Cursor ships Plan Mode as a product feature (Shift+Tab): the agent asks clarifying questions, researches
+    the codebase, and generates a reviewable, editable implementation plan before any code is written (undated page;
+    date = retrieval date)'
+- tier: T1
+  match: aliased
+  mechanism_quote: For changes you want to review before they touch disk, switch to plan mode. Claude reads files
+    and proposes a plan but makes no edits until you approve.
+  source: Anthropic - Claude Code docs, Common workflows (plan mode)
+  url: https://code.claude.com/docs/en/common-workflows
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Claude Code ships a runnable plan mode (claude --permission-mode plan, Shift+Tab toggle) that restricts
+    the agent to read-only analysis and plan generation until the user approves (undated page; date = retrieval
+    date)
+- tier: T1
+  match: aliased
+  mechanism_quote: Conducts deep-dive questioning across all aspects of a plan, walking through decision trees branch-by-branch
+    until shared understanding is reached
+  source: Matt Pocock - 'grill-me' skill on skills.sh (mattpocock/skills)
+  url: https://skills.sh/mattpocock/skills/grill-me
+  date: '2026-03-13'
+  retrieved: '2026-07-02'
+  claim: 'An installable agent skill (npx skills add, 433.8K installs shown, first seen Mar 13 2026) that implements
+    the interview phase: systematic pre-implementation questioning of the user before code is generated'
+- tier: T2
+  match: aliased
+  mechanism_quote: For larger features, have Claude interview you first. Start with a minimal prompt and ask Claude
+    to interview you using the AskUserQuestion tool.
+  source: Anthropic - Claude Code docs, Best practices ('Explore first, then plan, then code' and 'Let Claude interview
+    you')
+  url: https://code.claude.com/docs/en/best-practices
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: 'Anthropic''s official best-practices doc prescribes both halves of the mechanism: separate exploration/planning
+    from implementation via plan mode, and have the AI interview the developer to produce a spec before coding (undated
+    page; date = retrieval date)'
+- tier: T3
+  match: aliased
+  mechanism_quote: We introduce a novel framework named ClarifyGPT, which aims to enhance code generation by empowering
+    LLMs with the ability to identify ambiguous requirements and ask targeted clarifying questions.
+  source: 'Fangwen Mu et al. - ClarifyGPT: Empowering LLM-based Code Generation with Intention Clarification (arXiv
+    2310.10996, also ACM DOI 10.1145/3660810)'
+  url: https://arxiv.org/abs/2310.10996
+  date: '2023-10-17'
+  retrieved: '2026-07-02'
+  claim: Peer-reviewed framework showing that detecting ambiguous requirements and asking targeted clarifying questions
+    before generating code raised GPT-4 Pass@1 from 70.96% to 80.80% on MBPP-sanitized
+- tier: T4
+  match: unnamed
+  mechanism_quote: Ask me one question at a time so we can develop a thorough, step-by-step spec for this idea.
+  source: Harper Reed - 'My LLM codegen workflow atm' (harper.blog)
+  url: https://harper.blog/2025/02/16/my-llm-codegen-workflow-atm/
+  date: '2025-02-16'
+  retrieved: '2026-07-02'
+  claim: 'Practitioner workflow with full prompts: an LLM interviews the developer one question at a time to build
+    a spec, a reasoning model turns the spec into a step-by-step plan (prompt_plan.md), and only then is code generated'
+- tier: T4
+  match: aliased
+  mechanism_quote: This pattern changes the AI's behavior from “generate immediately” to “interview first, then
+    implement.”
+  source: Cowrie (Dev @ Bswen) - 'How to Get AI Coding Assistants to Ask Clarifying Questions Before Generating
+    Code' (docs.bswen.com)
+  url: https://docs.bswen.com/blog/2026-04-01-ai-clarifying-questions-codex/
+  date: '2026-04-01'
+  retrieved: '2026-07-02'
+  claim: Practitioner post with the full 5-sentence 'grill-me' prompt and a derived 'clarify-first' SKILL.md, reporting
+    fewer wrong assumptions and fewer revision cycles when Codex interviews before implementing
+verdict: verified


### PR DESCRIPTION
## Evidence summary

**In plain terms**: this practice is demonstrably established in industry — 3 shipped tool(s) implement it; 1 official vendor doc(s) prescribe it; 1 conference talk(s)/paper(s) present it; 2 practitioner post(s) show working implementations. However, the industry mostly practices it under **other names**: *plan mode* (Cursor, Claude Code).

| Field | Value |
|---|---|
| Verdict (computed) | **verified** |
| Adoption score (computed) | 26 — `26 = 3×T1 (15) + 1×T2 (4) + 1×T3 (3) + 2×T4 (4)` — out of a possible 45 (3 entries max per tier). |
| Naming alignment (computed) | weak |
| Search queries used | 7 / 12 |

### How to read these fields

**Adoption score** — weighted sum of evidence entries that survived independent verification (at most 3 count per tier):
shipped product/tool (T1) = 5 pts · official vendor docs (T2) = 4 · conference talk or peer-reviewed paper (T3) = 3 · practitioner blog with implementation detail (T4) = 2 · social/podcast mention (T5) = 1. Range 0–45.
Rough bands: **0–2** = no meaningful evidence · **3–7** = thin signal · **8+ with a T1–T3 anchor** = established practice, not just blog chatter.

**Verdict** — computed by `scripts/validate-evidence.py`, never asserted:
- **verified** = score ≥ 8 AND at least one T1–T3 entry (a runnable tool, canonical docs, or the conference/paper record — not just opinions).
- **weak** = evidence exists but is thin, or high volume built only on T4/T5 blogs and mentions.
- **unverified** = score ≤ 2 after all three search modes ran — the practice itself may not be established (triggers a human demotion discussion, never automatic removal).

**Naming alignment** — a separate question from the verdict: *does the industry call it what we call it?*
- **strong** = more than half of the evidence uses this catalog's pattern name.
- **weak** = the practice is real but most sources name it something else (see terminology variants).
- **none** = no source uses our name or a recognized alias.
`verified` + weak/none naming means "real practice, our name for it" — an alias/rename discussion, **not** an evidence problem.

**Search queries used** — each pattern is bounded to 12 queries across three modes (name, mechanism-with-name-excluded, artifact/code-fingerprint). A value under 12 means the search finished naturally; nothing was truncated by the cap.

### Accepted evidence (survived independent verify pass)

| Tier | Match | Source | Date |
|---|---|---|---|
| T1 | aliased | [Cursor - Plan Mode documentation](https://cursor.com/docs/agent/plan-mode) | 2026-07-02 |
| T1 | aliased | [Anthropic - Claude Code docs, Common workflows (plan mode)](https://code.claude.com/docs/en/common-workflows) | 2026-07-02 |
| T1 | aliased | [Matt Pocock - 'grill-me' skill on skills.sh (mattpocock/skills)](https://skills.sh/mattpocock/skills/grill-me) | 2026-03-13 |
| T2 | aliased | [Anthropic - Claude Code docs, Best practices ('Explore first, then plan, then code' and 'Let Claude interview you')](https://code.claude.com/docs/en/best-practices) | 2026-07-02 |
| T3 | aliased | [Fangwen Mu et al. - ClarifyGPT: Empowering LLM-based Code Generation with Intention Clarification (arXiv 2310.10996, also ACM DOI 10.1145/3660810)](https://arxiv.org/abs/2310.10996) | 2023-10-17 |
| T4 | unnamed | [Harper Reed - 'My LLM codegen workflow atm' (harper.blog)](https://harper.blog/2025/02/16/my-llm-codegen-workflow-atm/) | 2025-02-16 |
| T4 | aliased | [Cowrie (Dev @ Bswen) - 'How to Get AI Coding Assistants to Ask Clarifying Questions Before Generating Code' (docs.bswen.com)](https://docs.bswen.com/blog/2026-04-01-ai-clarifying-questions-codex/) | 2026-04-01 |

### Terminology variants observed

- **Plan Mode** — used by Cursor (product feature) and Anthropic Claude Code (permission mode)
- **Explore first, then plan, then code (Explore, plan, code, commit)** — used by Anthropic Claude Code best-practices docs
- **Let Claude interview you** — used by Anthropic Claude Code best-practices docs
- **grill-me / clarify-first skill** — used by Matt Pocock (skills.sh) and bswen.com practitioner writeup
- **intention clarification** — used by Mu et al., ClarifyGPT (arXiv/ACM FSE)
- **brainstorm spec, then plan a plan, then execute** — used by Harper Reed (harper.blog)

### Search coverage

Name mode: the exact name 'Planned Implementation' appears only in this catalog; the industry-dominant alias is 'Plan Mode' (Cursor, Claude Code, OpenAI Codex discussion). Mechanism mode found vendor docs prescribing interview+plan-before-code and the peer-reviewed ClarifyGPT paper quantifying the benefit. Artifact mode (gh search, 2 queries): 15 public repos embed Harper Reed's interview prompt verbatim in agent command files (verified foobacca/dotfiles claude/commands/brainstorm.md content via GitHub API) and 15 more instruct 'ask clarifying questions before writing any code' in CLAUDE.md/.cursorrules/AGENTS.md/SKILL.md - widespread unnamed adoption not listed as candidates because individual file commit dates were not verified. Addy Osmani's good-spec post (strong mechanism match) was dropped for lack of a determinable publication date; budget was 12 queries, 7 used, no mode exhausted.

All three search modes ran (name, mechanism with pattern name excluded, artifact/code fingerprint). Every URL was fetched during this run by the collector and re-fetched by an independent grader (producer ≠ grader); score, verdict, and naming alignment are computed by `scripts/validate-evidence.py`, not asserted.

### Naming recommendation (pattern-spec checked)

**Recommendation: KEEP + alias** (added in #29), **with "Plan Mode" as the evidence-maximal rename option** if recognition is prioritized.

- **Dominant industry term**: *plan mode* — genericized across vendors: Cursor ships Plan Mode (T1), Claude Code ships plan mode (T1/T2), and the term recurs in Codex discussions. This is the single strongest cross-vendor term found in the run.
- **Spec checklist on "Plan Mode"**: two words Title Case ✓ · Noun+Noun ✓ · unique ✓ · "Use the Plan Mode pattern to..." ✓ · **but** it strains the "describes a principle, not a tool" rule — plan mode is a shipped feature name, and the pattern is deliberately broader (interview → constraints → plan, of which the feature is one mechanism).
- **The trade**: keep + alias preserves the broader principle framing; rename to Plan Mode maximizes findability at the cost of narrowing perceived scope. The evidence supports either; the principle-vs-recognition weighting is the human call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)