### PR TITLE
docs(verification): verify progressive-enhancement — verified, score 23

### DIFF
--- a/verification/evidence/progressive-enhancement.yaml
+++ b/verification/evidence/progressive-enhancement.yaml
@@ -1,0 +1,95 @@
+pattern: Progressive Enhancement
+slug: progressive-enhancement
+verified: '2026-07-02'
+adoption_score: 23
+naming_alignment: weak
+terminology_variants:
+- term: Break complex tasks into simpler tasks
+  used_by: GitHub Docs (Copilot prompt engineering)
+  url: https://docs.github.com/en/copilot/concepts/prompting/prompt-engineering
+- term: bite sized steps
+  used_by: Aider official docs
+  url: https://aider.chat/docs/usage/tips.html
+- term: prompt plan / small, iterative chunks
+  used_by: Harper Reed (harper.blog), copied verbatim into 161+ GitHub files
+  url: https://harper.blog/2025/02/16/my-llm-codegen-workflow-atm/
+- term: Incremental Development Rules
+  used_by: Rakia Ben Sassi (The Engineering Wisdom)
+  url: https://rakiabensassi.substack.com/p/stop-just-prompting-your-ai-coder
+evidence:
+- tier: T2
+  match: aliased
+  mechanism_quote: If you want Copilot to complete a complex or large task, break the task into multiple simple,
+    small tasks.
+  source: GitHub Docs, "Prompt engineering for GitHub Copilot Chat"
+  url: https://docs.github.com/en/copilot/concepts/prompting/prompt-engineering
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: GitHub's official Copilot documentation instructs users to complete complex or large tasks by breaking
+    them into multiple simple, small tasks accomplished one by one, with a worked word-search example decomposed
+    into four sequential prompts (undated page; date = retrieval date)
+- tier: T2
+  match: aliased
+  mechanism_quote: Break your goal down into bite sized steps. Do them one at a time.
+  source: Aider (Paul Gauthier), official usage docs "Tips"
+  url: https://aider.chat/docs/usage/tips.html
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Aider's official documentation tells users to break their goal into bite-sized steps done one at a time,
+    adjusting the files in the chat between steps, and to discuss a plan first for complex changes (undated page;
+    date = retrieval date)
+- tier: T1
+  match: unnamed
+  mechanism_quote: '**Single-tick build-loop conductor** — advances one ready spec by one pipeline stage (plan →
+    plan-review → work → make-pr, plus an optional `qa` stage when `pipeline.qa==on`) per tick, ends with a `PILOT_VERDICT`
+    line; drive it with `/loop` or `/goal`'
+  source: gmickel/flow-next (Claude Code/Codex workflow plugin, 648 stars)
+  url: https://github.com/gmickel/flow-next
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Shipped plugin whose pilot loop advances one ready spec by one pipeline stage per tick (plan, plan-review,
+    work, make-pr), producing a draft PR per small increment instead of one large generation; Ralph mode drives
+    a fresh session per iteration (README undated; date = repo last-push date, retrieved this run)
+- tier: T1
+  match: unnamed
+  mechanism_quote: Then, once you have a solid plan, break it down into small, iterative chunks that build on each
+    other.
+  source: harperreed/dotfiles, shipped .claude/commands/plan.md (representative of GitHub-wide artifact fingerprint)
+  url: https://github.com/harperreed/dotfiles/blob/master/.claude/commands/plan.md
+  date: '2026-07-02'
+  retrieved: '2026-07-02'
+  claim: Runnable Claude Code command that plans a project as small iterative chunks implemented step-by-step; GitHub
+    code search this run found 519 files named prompt_plan.md and 161 files containing this exact prompt sentence
+    across repos, including Amazon Q prompt configs and Claude Code plugins (undated file; date = retrieval date)
+- tier: T4
+  match: unnamed
+  mechanism_quote: Draft a detailed, step-by-step blueprint for building this project. Then, once you have a solid
+    plan, break it down into small, iterative chunks that build on each other.
+  source: Harper Reed, "My LLM codegen workflow atm" (harper.blog)
+  url: https://harper.blog/2025/02/16/my-llm-codegen-workflow-atm/
+  date: '2025-02-16'
+  retrieved: '2026-07-02'
+  claim: 'Practitioner workflow post with full prompts: plan a spec, break it into small iterative chunks saved
+    as prompt_plan.md, then execute each prompt one at a time in claude/aider, running code and tests before moving
+    to the next prompt'
+- tier: T4
+  match: named
+  source: Rakia Ben Sassi, "Stop Just Prompting Your AI Coder. Start Context Engineering." (The Engineering Wisdom,
+    Substack)
+  url: https://rakiabensassi.substack.com/p/stop-just-prompting-your-ai-coder
+  date: '2025-11-26'
+  retrieved: '2026-07-02'
+  claim: 'Practitioner post showing a full claude.md config whose "Incremental Development Rules" section names
+    "Progressive enhancement" as a rule alongside "Start minimal", "Iterate with purpose - Each iteration should
+    be reviewable and deployable", "No ''big bang'' commits", and "NEVER Generate: Entire features in one response"'
+- tier: T5
+  match: unnamed
+  mechanism_quote: Work in smaller steps and get more feedback.
+  source: 'Kent Beck (guest), O11ycast Ep. #80 "Augmented Coding with Kent Beck" (Heavybit podcast, transcript)'
+  url: https://www.heavybit.com/library/podcasts/o11ycast/ep-80-augmented-coding-with-kent-beck
+  date: '2025-04-30'
+  retrieved: '2026-07-02'
+  claim: Kent Beck, discussing AI-assisted ("augmented") coding, states the core wisdom he would impart is working
+    in smaller steps with more feedback, with co-host describing the discipline of going back and redoing work in
+    smaller increments when a big swing fails
+verdict: verified


### PR DESCRIPTION
## Evidence summary

**In plain terms**: this practice is demonstrably established in industry — 2 shipped tool(s) implement it; 2 official vendor doc(s) prescribe it; 2 practitioner post(s) show working implementations; 1 dated public discussion(s) reference it. However, the industry mostly practices it under **other names**: no single stable term — *break tasks into smaller tasks*, *bite-sized steps*, *prompt plan*.

| Field | Value |
|---|---|
| Verdict (computed) | **verified** |
| Adoption score (computed) | 23 — `23 = 2×T1 (10) + 2×T2 (8) + 2×T4 (4) + 1×T5 (1)` — out of a possible 45 (3 entries max per tier). |
| Naming alignment (computed) | weak |
| Search queries used | 9 / 12 |

### How to read these fields

**Adoption score** — weighted sum of evidence entries that survived independent verification (at most 3 count per tier):
shipped product/tool (T1) = 5 pts · official vendor docs (T2) = 4 · conference talk or peer-reviewed paper (T3) = 3 · practitioner blog with implementation detail (T4) = 2 · social/podcast mention (T5) = 1. Range 0–45.
Rough bands: **0–2** = no meaningful evidence · **3–7** = thin signal · **8+ with a T1–T3 anchor** = established practice, not just blog chatter.

**Verdict** — computed by `scripts/validate-evidence.py`, never asserted:
- **verified** = score ≥ 8 AND at least one T1–T3 entry (a runnable tool, canonical docs, or the conference/paper record — not just opinions).
- **weak** = evidence exists but is thin, or high volume built only on T4/T5 blogs and mentions.
- **unverified** = score ≤ 2 after all three search modes ran — the practice itself may not be established (triggers a human demotion discussion, never automatic removal).

**Naming alignment** — a separate question from the verdict: *does the industry call it what we call it?*
- **strong** = more than half of the evidence uses this catalog's pattern name.
- **weak** = the practice is real but most sources name it something else (see terminology variants).
- **none** = no source uses our name or a recognized alias.
`verified` + weak/none naming means "real practice, our name for it" — an alias/rename discussion, **not** an evidence problem.

**Search queries used** — each pattern is bounded to 12 queries across three modes (name, mechanism-with-name-excluded, artifact/code-fingerprint). A value under 12 means the search finished naturally; nothing was truncated by the cap.

### Accepted evidence (survived independent verify pass)

| Tier | Match | Source | Date |
|---|---|---|---|
| T2 | aliased | [GitHub Docs, "Prompt engineering for GitHub Copilot Chat"](https://docs.github.com/en/copilot/concepts/prompting/prompt-engineering) | 2026-07-02 |
| T2 | aliased | [Aider (Paul Gauthier), official usage docs "Tips"](https://aider.chat/docs/usage/tips.html) | 2026-07-02 |
| T1 | unnamed | [gmickel/flow-next (Claude Code/Codex workflow plugin, 648 stars)](https://github.com/gmickel/flow-next) | 2026-07-02 |
| T1 | unnamed | [harperreed/dotfiles, shipped .claude/commands/plan.md (representative of GitHub-wide artifact fingerprint)](https://github.com/harperreed/dotfiles/blob/master/.claude/commands/plan.md) | 2026-07-02 |
| T4 | unnamed | [Harper Reed, "My LLM codegen workflow atm" (harper.blog)](https://harper.blog/2025/02/16/my-llm-codegen-workflow-atm/) | 2025-02-16 |
| T4 | named | [Rakia Ben Sassi, "Stop Just Prompting Your AI Coder. Start Context Engineering." (The Engineering Wisdom, Substack)](https://rakiabensassi.substack.com/p/stop-just-prompting-your-ai-coder) | 2025-11-26 |
| T5 | unnamed | [Kent Beck (guest), O11ycast Ep. #80 "Augmented Coding with Kent Beck" (Heavybit podcast, transcript)](https://www.heavybit.com/library/podcasts/o11ycast/ep-80-augmented-coding-with-kent-beck) | 2025-04-30 |

### Terminology variants observed

- **Break complex tasks into simpler tasks** — used by GitHub Docs (Copilot prompt engineering)
- **bite sized steps** — used by Aider official docs
- **prompt plan / small, iterative chunks** — used by Harper Reed (harper.blog), copied verbatim into 161+ GitHub files
- **Incremental Development Rules** — used by Rakia Ben Sassi (The Engineering Wisdom)

### Search coverage

Name mode mostly collided with the unrelated web-design "progressive enhancement" term but found one named practitioner use (Ben Sassi). Mechanism mode found the practice canonically documented by GitHub Copilot and aider docs and preached by Harper Reed and Kent Beck under aliases like "break complex tasks into simpler tasks" and "bite sized steps". Artifact mode (gh code search) found 519 prompt_plan.md files and 161 verbatim copies of Harper's iterative-chunks planning prompt; skipped OpenAI/Google generic task-splitting docs (prompting-generic, not deployable code iterations) and martinfowler.com SPDD (small steps only in its refactoring rule) as weak mechanism matches.

All three search modes ran (name, mechanism with pattern name excluded, artifact/code fingerprint). Every URL was fetched during this run by the collector and re-fetched by an independent grader (producer ≠ grader); score, verdict, and naming alignment are computed by `scripts/validate-evidence.py`, not asserted.

### Naming recommendation (pattern-spec checked)

**Recommendation: RENAME to "Incremental Generation"** — strong, collision-driven.

- **Documented problem**: the run's name-mode searches collided head-on with the long-established *web-design* meaning of "progressive enhancement" (layered CSS/JS fallbacks) — a different practice entirely. The catalog name is effectively unfindable, and the naming alignment is carried by a single practitioner post.
- **Dominant industry term**: none to borrow — sources describe the practice, not a name: "break complex tasks into simpler tasks" (GitHub Copilot docs, T2), "bite sized steps" (aider docs, T2), "small, iterative chunks" (Harper Reed, T4), Kent Beck on small steps (T5). A naming vacuum, so the spec's preferred vocabulary decides.
- **Spec checklist on "Incremental Generation"**: two words Title Case ✓ · Adj+Noun ✓ · "Generation" is on pattern-spec's preferred domain-terms list ✓ · unique across catalog + experiments ✓ · "Use the Incremental Generation pattern to build features in small, deployable steps" ✓ · no collision with any established term ✓. Alternative considered: "Iterative Generation" (equally compliant; "incremental" better implies each step ships).

Renaming is a human decision; `PATTERN_MIGRATION_GUIDE.md` governs the mechanics if accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)