### PR TITLE
feat(verification): require spec-checked naming recommendations from verify-patterns

### DIFF
--- a/.claude/commands/verify-patterns.md
+++ b/.claude/commands/verify-patterns.md
@@ -191,9 +191,25 @@ not a search-method failure. Demotion is a human decision.
 **(d)** If a terminology variant dominates industry usage: add an alias mention in the pattern
 description ("also referred to as X by Y") in the batched PR. Never rename.
 
-**(e)** `verified` with `naming_alignment: none` or `weak`: flag in the final report as a naming
-discussion (with the dominant industry term, if one exists). Renaming is a human decision — do not
-open a PR for it.
+**(e)** `verified` with `naming_alignment: none` or `weak`: produce a **naming recommendation**,
+not just a flag. For each such pattern:
+
+1. Identify the dominant industry term(s) from `terminology_variants` — dominance means multiple
+   independent (unaffiliated) sources, weighted by evidence tier.
+2. Derive candidate names from the dominant term and run each through the pattern-spec.md naming
+   validation checklist: exactly two words Title Case (hyphenated compounds count as one word),
+   Noun+Noun or Adj+Noun, no "AI" prefix, domain-specific vocabulary, 2-4 syllables per word,
+   unique across the catalog including experiments, passes the "Use the X Y pattern to..." test,
+   and describes a principle rather than a single vendor's feature name.
+3. Recommend exactly one action, with rationale citing specific evidence entries by source:
+   - **keep** — current name is defensible; no spec-compliant, evidence-backed candidate beats it.
+   - **keep + alias** — record the industry term via a Phase 3(d) alias mention.
+   - **rename to <Candidate>** — only when the candidate passes the full checklist AND either the
+     industry term dominates across independent sources or the current name has a documented
+     collision/discoverability problem (e.g. name-mode searches drown in an unrelated meaning).
+4. Record the recommendation in the final report. Renaming remains a human decision — never open
+   a rename PR; if a human accepts a rename, PATTERN_MIGRATION_GUIDE.md governs the mechanics
+   (anchors, slugs, evidence file key, site regeneration).
 
 ## Phase 4 — Unknown-unknowns discovery
 
@@ -219,8 +235,11 @@ open a PR for it.
 ## Final report (never committed)
 
 Table: pattern | prior verdict | new verdict | score delta | naming_alignment | PR/issue link.
+Then the Phase 3(e) naming recommendations, one row per `verified` pattern with weak/no naming
+alignment: pattern | dominant industry term | spec-checked candidate | recommendation (keep /
+keep + alias / rename to X) | evidence basis. Show why rejected candidates failed the checklist.
 Then discovery candidates: term (or "unnamed" + proposed name) | sources | closest existing pattern.
-End with the three highest-leverage follow-ups, keeping naming discussions (`verified` but weak/no
+End with the three highest-leverage follow-ups, keeping naming recommendations (`verified` but weak/no
 naming alignment) separate from evidence gaps (`unverified`). Note anything skipped due to bounds
 (query caps, PR cap) — silent truncation reads as full coverage.
 


### PR DESCRIPTION
## Summary

Extends Phase 3(e) of `/verify-patterns`: when a pattern is `verified` but the industry names the practice differently (`naming_alignment: weak` or `none`), the pipeline must no longer just flag a "naming discussion" — it must return a specific recommendation:

1. Identify the dominant industry term from the collected `terminology_variants` (dominance = multiple unaffiliated sources, tier-weighted).
2. Run candidate names through the full pattern-spec.md naming checklist (two words Title Case, Noun+Noun/Adj+Noun, no "AI" prefix, unique in catalog, "Use the X Y pattern to..." test, principle-not-tool).
3. Recommend exactly one action — **keep**, **keep + alias**, or **rename to \<Candidate\>** — with rationale citing specific evidence entries. Rename is only recommendable when the candidate passes the full checklist AND the term dominates or the current name has a documented collision problem.

The final-report spec gains a matching naming-recommendations table. Renaming itself stays a human decision (never a rename PR); `PATTERN_MIGRATION_GUIDE.md` governs mechanics if accepted.

First application of this rule: naming recommendations for the 9 weak-alignment patterns from the 2026-07-02 run are appended to their evidence PRs (#19–#24, #26–#28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for handling verified patterns with weak or missing naming alignment.
  * Added a clearer reporting format that includes recommended naming decisions and supporting evidence.
  * Expanded instructions to explain why non-selected naming options did not meet the checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->