### PR TITLE
fix(verification): fail closed on Claude execution errors

### DIFF
--- a/.github/workflows/verify-patterns.yml
+++ b/.github/workflows/verify-patterns.yml
@@ -308,6 +308,14 @@ jobs:
             --allowedTools
             "Bash(python3 scripts/evidence_content.py:*),Bash(python3 scripts/validate-evidence.py:*),Bash(python3 scripts/generate-verification-status.py:*),Bash(python3 scripts/generate-patterns-data.py:*),Bash(date -I),Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,Task"
 
+      # claude-code-action currently keys its conclusion only off the result
+      # subtype. Fail closed on the contradictory success + is_error result and
+      # keep raw model output out of the public Actions log and artifacts.
+      - name: Require successful Claude execution
+        env:
+          CLAUDE_EXECUTION_FILE: ${{ steps.research.outputs.execution_file }}
+        run: python3 scripts/check-claude-execution.py
+
       - name: Scan fixed-path candidate bundle
         env:
           EXPECTED_SCANNER_SHA256: ${{ needs.prepare.outputs.scanner_sha256 }}

--- a/scripts/check-claude-execution.py
+++ b/scripts/check-claude-execution.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Fail closed when Claude Code reports an unsuccessful research execution.
+
+The Claude Code Action can currently emit a result whose subtype is ``success``
+while ``is_error`` is true.  The action treats that combination as successful,
+so workflows must independently inspect its local execution file before using
+any candidate output.  This checker deliberately prints only fixed diagnostic
+categories; raw model output may contain secrets or untrusted web content.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+
+MAX_EXECUTION_BYTES = 64 * 1024 * 1024
+
+
+def _diagnostic_text(result: dict[str, Any]) -> str:
+    """Return bounded text used only to choose a safe diagnostic category."""
+    values: list[str] = []
+    for key in ("result", "errors"):
+        value = result.get(key)
+        if isinstance(value, str):
+            values.append(value)
+        elif isinstance(value, list):
+            values.extend(item for item in value if isinstance(item, str))
+    return " ".join(values)[:65_536].casefold()
+
+
+def _classify_failure(result: dict[str, Any]) -> str:
+    text = _diagnostic_text(result)
+    classifiers = (
+        (
+            "authentication_failed",
+            (
+                "authentication",
+                "invalid x-api-key",
+                "invalid api key",
+                "unauthorized",
+                "status 401",
+                " 401",
+            ),
+        ),
+        (
+            "authorization_failed",
+            ("forbidden", "permission denied", "status 403", " 403"),
+        ),
+        (
+            "billing_or_credit_error",
+            (
+                "credit",
+                "billing",
+                "payment required",
+                "usage limit",
+                "status 402",
+                " 402",
+            ),
+        ),
+        ("rate_limited", ("rate_limit", "rate limit", "status 429", " 429")),
+        ("service_overloaded", ("overloaded", "status 529", " 529")),
+        ("request_timed_out", ("timed out", "timeout")),
+        ("turn_limit_reached", ("max turns", "maximum turns", "error_max_turns")),
+        ("invalid_request", ("invalid_request", "invalid request", "status 400", " 400")),
+    )
+    for category, markers in classifiers:
+        if any(marker in text for marker in markers):
+            return category
+
+    model_markers = (
+        "not found",
+        "not_found",
+        "does not exist",
+        "not available",
+        "access",
+    )
+    if "model" in text and any(marker in text for marker in model_markers):
+        return "model_unavailable"
+
+    subtype = result.get("subtype")
+    if subtype == "error_max_turns":
+        return "turn_limit_reached"
+    if subtype == "error_max_budget_usd":
+        return "budget_limit_reached"
+    if subtype == "error_during_execution":
+        return "execution_error"
+    return "unspecified_execution_error"
+
+
+def validate_execution_file(
+    path: Path | None, *, runner_temp: Path | None = None
+) -> str | None:
+    """Return a safe failure category, or ``None`` for a genuine success."""
+    if path is None:
+        return "missing_execution_file"
+    try:
+        stat = path.lstat()
+    except OSError:
+        return "missing_execution_file"
+    if path.is_symlink() or not path.is_file():
+        return "invalid_execution_file"
+    if runner_temp is not None:
+        try:
+            expected = (runner_temp / "claude-execution-output.json").resolve()
+            actual = path.resolve(strict=True)
+        except OSError:
+            return "invalid_execution_file"
+        if actual != expected:
+            return "unexpected_execution_file_path"
+    if stat.st_size > MAX_EXECUTION_BYTES:
+        return "oversized_execution_file"
+
+    try:
+        events = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return "invalid_execution_file"
+    if not isinstance(events, list) or not events:
+        return "invalid_execution_file"
+
+    results = [
+        event
+        for event in events
+        if isinstance(event, dict) and event.get("type") == "result"
+    ]
+    if len(results) != 1 or events[-1] is not results[0]:
+        return "missing_final_result"
+    result = results[0]
+    if result.get("subtype") == "success" and result.get("is_error") is False:
+        return None
+    return _classify_failure(result)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Require a genuine successful Claude Code execution result."
+    )
+    parser.add_argument(
+        "execution_file",
+        nargs="?",
+        default=os.environ.get("CLAUDE_EXECUTION_FILE", ""),
+    )
+    args = parser.parse_args(argv)
+
+    runner_temp_value = os.environ.get("RUNNER_TEMP", "")
+    runner_temp = Path(runner_temp_value) if runner_temp_value else None
+    execution_file = Path(args.execution_file) if args.execution_file else None
+    failure = validate_execution_file(execution_file, runner_temp=runner_temp)
+    if failure is not None:
+        print(
+            f"::error::Claude research did not complete successfully ({failure})",
+            file=sys.stderr,
+        )
+        return 1
+    print("Claude research execution result is successful")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_claude_execution.py
+++ b/tests/test_claude_execution.py
@@ -1,0 +1,96 @@
+"""Tests for the fail-closed Claude execution-result checker."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parent.parent / "scripts" / "check-claude-execution.py"
+SPEC = importlib.util.spec_from_file_location("check_claude_execution", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def write_events(tmp_path, events):
+    path = tmp_path / "claude-execution-output.json"
+    path.write_text(json.dumps(events), encoding="utf-8")
+    return path
+
+
+def test_accepts_only_explicit_non_error_success(tmp_path):
+    path = write_events(
+        tmp_path,
+        [{"type": "system", "subtype": "init"},
+         {"type": "result", "subtype": "success", "is_error": False}],
+    )
+    assert MODULE.validate_execution_file(path) is None
+
+
+def test_rejects_success_subtype_when_is_error_is_true(tmp_path):
+    path = write_events(
+        tmp_path,
+        [{"type": "result", "subtype": "success", "is_error": True,
+          "result": "API Error: invalid x-api-key"}],
+    )
+    assert MODULE.validate_execution_file(path) == "authentication_failed"
+
+
+def test_reports_only_safe_category_for_sensitive_error(
+    tmp_path, capsys, monkeypatch
+):
+    monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+    secret = "sk-ant-api03-" + "A" * 48
+    path = write_events(
+        tmp_path,
+        [{"type": "result", "subtype": "success", "is_error": True,
+          "result": f"API Error: invalid API key {secret}"}],
+    )
+
+    assert MODULE.main([str(path)]) == 1
+
+    output = capsys.readouterr().err
+    assert "authentication_failed" in output
+    assert secret not in output
+
+
+def test_rejects_missing_or_nonfinal_result(tmp_path):
+    missing = tmp_path / "missing.json"
+    assert MODULE.validate_execution_file(missing) == "missing_execution_file"
+    assert MODULE.validate_execution_file(None) == "missing_execution_file"
+
+    path = write_events(tmp_path, [{"type": "assistant", "message": {}}])
+    assert MODULE.validate_execution_file(path) == "missing_final_result"
+
+    path = write_events(
+        tmp_path,
+        [{"type": "result", "subtype": "success", "is_error": False},
+         {"type": "result", "subtype": "success", "is_error": False}],
+    )
+    assert MODULE.validate_execution_file(path) == "missing_final_result"
+
+
+def test_rejects_malformed_and_symlinked_files(tmp_path):
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("not json", encoding="utf-8")
+    assert MODULE.validate_execution_file(malformed) == "invalid_execution_file"
+
+    target = write_events(
+        tmp_path,
+        [{"type": "result", "subtype": "success", "is_error": False}],
+    )
+    link = tmp_path / "linked.json"
+    link.symlink_to(target)
+    assert MODULE.validate_execution_file(link) == "invalid_execution_file"
+
+
+def test_requires_the_fixed_runner_temp_path_when_configured(tmp_path):
+    path = write_events(
+        tmp_path,
+        [{"type": "result", "subtype": "success", "is_error": False}],
+    )
+    assert MODULE.validate_execution_file(path, runner_temp=tmp_path) is None
+
+    other = tmp_path / "other"
+    other.mkdir()
+    assert MODULE.validate_execution_file(path, runner_temp=other) == (
+        "unexpected_execution_file_path")

--- a/tests/test_verification_workflows.py
+++ b/tests/test_verification_workflows.py
@@ -41,6 +41,13 @@ def test_research_has_read_only_github_token_and_exact_scope_gate():
     assert "Enforce exact research scope and current-run provenance" in text
     assert "evidence scope mismatch; missing=" in text
     assert "EVIDENCE_SCOPE_SLUGS" in text
+    guard_step = next(
+        step for step in research["steps"]
+        if step.get("name") == "Require successful Claude execution")
+    assert guard_step["env"]["CLAUDE_EXECUTION_FILE"] == (
+        "${{ steps.research.outputs.execution_file }}")
+    assert guard_step["run"] == "python3 scripts/check-claude-execution.py"
+    assert "show_full_output" not in action_step["with"]
     assert "verify-patterns-execution-log" not in text
 
 


### PR DESCRIPTION
## Summary

- reject contradictory `success` + `is_error` results from the Claude action
- validate the fixed runner-local execution file without exposing raw model output
- emit only safe auth, billing, model, rate-limit, and execution diagnostic categories
- add unit and workflow-structure regression coverage

## Verification

- `python -m pytest tests -q -m "not slow"` (218 passed, 3 deselected)
- `actionlint .github/workflows/verify-patterns.yml`
- `python -m compileall -q scripts/check-claude-execution.py`
- `git diff --check`

## Live failure addressed

Run 29103690370 returned `subtype: success` with `is_error: true`; the pinned upstream action ignored the error flag and uploaded an unchanged candidate. This guard now fails before candidate publication and reports a sanitized category.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to confirm automated research executions complete successfully before results are processed.
  * Prevented sensitive raw execution output from appearing in public logs or artifacts.
  * Added safeguards for malformed, incomplete, contradictory, or unsafe execution results.

* **Tests**
  * Added coverage for successful and failed execution scenarios, sensitive error handling, invalid files, and workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->