### PR TITLE
fix(verification): publish validated provider result

### DIFF
--- a/.github/workflows/verify-patterns.yml
+++ b/.github/workflows/verify-patterns.yml
@@ -1068,7 +1068,14 @@ jobs:
   publish:
     name: Publish validated candidate
     needs: [prepare, validate-candidate]
-    if: needs.validate-candidate.outputs.has_changes == 'true'
+    # validate-candidate intentionally tolerates the unused provider job being
+    # skipped. Override GitHub's implicit success() here as well so that skip
+    # does not propagate through the dependency chain and suppress a real diff.
+    if: >-
+      !cancelled() &&
+      needs.prepare.result == 'success' &&
+      needs.validate-candidate.result == 'success' &&
+      needs.validate-candidate.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/tests/test_verification_workflows.py
+++ b/tests/test_verification_workflows.py
@@ -83,6 +83,18 @@ def test_provider_jobs_are_mutually_exclusive_and_least_privilege():
     assert "research-anthropic.result == 'success'" in validation["if"]
 
 
+def test_publish_overrides_skipped_unused_provider_propagation():
+    workflow = load_workflow(VERIFY)
+    publish = workflow["jobs"]["publish"]
+    condition = publish["if"]
+
+    assert publish["needs"] == ["prepare", "validate-candidate"]
+    assert condition.startswith("!cancelled()")
+    assert "needs.prepare.result == 'success'" in condition
+    assert "needs.validate-candidate.result == 'success'" in condition
+    assert "needs.validate-candidate.outputs.has_changes == 'true'" in condition
+
+
 def test_openai_research_uses_pinned_bounded_codex_action():
     workflow = load_workflow(VERIFY)
     research = workflow["jobs"]["research-openai"]


### PR DESCRIPTION
## Summary
- override implicit skipped-ancestor propagation for the publish job
- require prepare and candidate validation to succeed explicitly
- add a structural regression test for the mutually exclusive provider path

## Validation
- 246 repository tests passed, 3 slow tests deselected
- 105 focused evidence and trust-boundary tests passed
- deterministic evidence, generated status, and site artifacts are current
- actionlint passed
- zizmor reported no findings

## Live failure reproduced
Run 29112675133 produced and validated a real Event Automation candidate, but publication was skipped because the unused Anthropic provider job was intentionally skipped. This patch preserves fail-closed guards while allowing the successful selected provider result to publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workflow safeguards to prevent publication when required preparation or validation steps are skipped, cancelled, or fail.
  - Publication now proceeds only when validated changes are detected, while still allowing unaffected provider-specific checks to be skipped.
- **Tests**
  - Added regression coverage to verify publication conditions and prevent future workflow regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->