### PR TITLE
fix(ci): allow trusted status guidance updates

### DIFF
--- a/.github/workflows/trusted-evidence-validation.yml
+++ b/.github/workflows/trusted-evidence-validation.yml
@@ -112,9 +112,35 @@ jobs:
 
       - name: Recompute candidate status with trusted generator
         id: status
-        run: >-
-          python3 trusted/scripts/generate-verification-status.py
-          --root candidate --check
+        env:
+          SUBMITTED_STATUS: ${{ runner.temp }}/submitted-verification-status.md
+        run: |
+          set -euo pipefail
+          cp candidate/verification/STATUS.md "$SUBMITTED_STATUS"
+          python3 trusted/scripts/generate-verification-status.py --root candidate
+          python3 - "$SUBMITTED_STATUS" candidate/verification/STATUS.md <<'PY'
+          import difflib
+          import sys
+          from pathlib import Path
+
+          marker = "\n## How to refresh\n"
+          submitted = Path(sys.argv[1]).read_text(encoding="utf-8")
+          recomputed = Path(sys.argv[2]).read_text(encoding="utf-8")
+          if marker not in submitted or marker not in recomputed:
+              raise SystemExit("verification status is missing its guidance marker")
+          submitted_derived = submitted.split(marker, 1)[0]
+          recomputed_derived = recomputed.split(marker, 1)[0]
+          if submitted_derived != recomputed_derived:
+              print("Machine-derived verification status is out of date.", file=sys.stderr)
+              print("".join(difflib.unified_diff(
+                  submitted_derived.splitlines(keepends=True),
+                  recomputed_derived.splitlines(keepends=True),
+                  fromfile="submitted/verification/STATUS.md",
+                  tofile="trusted-recomputed/verification/STATUS.md",
+              )), file=sys.stderr)
+              raise SystemExit(1)
+          print("Machine-derived verification status is up to date")
+          PY
 
       - name: Publish trusted result on the candidate revision
         if: ${{ always() && steps.resolve.outputs.head_sha != '' }}

--- a/tests/test_verification_workflows.py
+++ b/tests/test_verification_workflows.py
@@ -892,6 +892,11 @@ def test_trusted_pr_workflow_executes_only_base_branch_validation_code():
     assert "trusted/scripts/generate-verification-status.py" in commands
     assert "candidate/scripts/" not in commands
     assert 'context="Trusted evidence checks"' in commands
+    status = named_step(job, "Recompute candidate status with trusted generator")
+    assert "trusted/scripts/generate-verification-status.py --root candidate" in status["run"]
+    assert 'marker = "\\n## How to refresh\\n"' in status["run"]
+    assert "submitted_derived != recomputed_derived" in status["run"]
+    assert "candidate/scripts/generate-verification-status.py" not in status["run"]
 
 
 def test_required_evidence_check_has_no_pull_request_path_filter():


### PR DESCRIPTION
## Summary

- keep the default-branch generator as the trust root for every machine-derived status count and table row
- allow the reviewable guidance section after the fixed `## How to refresh` marker to change without executing candidate code
- add structural regression coverage for the trusted comparison

This is the bootstrap compatibility fix for PR #75.

## Validation

- `python3 -m pytest tests/test_verification_workflows.py -q` (29 passed)
- workflow YAML parsed successfully
- confirmed PR #75 has an identical derived prefix and only a different guidance footer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification workflow checks to detect when submitted verification status content differs from trusted recomputation.
  * Verification failures now provide a clear difference report for easier diagnosis.

* **Tests**
  * Added coverage confirming trusted workflows use the approved status generator and avoid untrusted regeneration paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->