### PR TITLE
Reject package lifecycle hook changes

### DIFF
--- a/.github/workflows/trusted-evidence-validation.yml
+++ b/.github/workflows/trusted-evidence-validation.yml
@@ -168,6 +168,14 @@ jobs:
           candidate/experiments/NOTES.md
           candidate/verification
 
+      - name: Reject introduced or modified package lifecycle hooks
+        id: package-lifecycle
+        if: steps.resolve.outputs.eligible == 'true'
+        run: >-
+          python3 trusted/scripts/validate-package-lifecycle.py
+          --trusted-root trusted
+          --candidate-root candidate
+
       - name: Recompute candidate evidence with trusted validator
         id: evidence
         if: steps.resolve.outputs.eligible == 'true'
@@ -231,6 +239,7 @@ jobs:
               steps.workflow-policy.outcome != 'success' ||
               steps.install.outcome != 'success' ||
               steps.secret-scan.outcome != 'success' ||
+              steps.package-lifecycle.outcome != 'success' ||
               steps.evidence.outcome != 'success' ||
               steps.status.outcome != 'success'
             }}

--- a/scripts/validate-package-lifecycle.py
+++ b/scripts/validate-package-lifecycle.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Reject introduced or modified package-manager lifecycle hooks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+LIFECYCLE_SCRIPTS = {
+    "preinstall",
+    "install",
+    "postinstall",
+    "prepare",
+    "prepublish",
+    "prepublishOnly",
+}
+IGNORED_DIRECTORIES = {".git", ".venv", "node_modules"}
+
+
+def manifests(root: Path) -> dict[Path, Path]:
+    """Return package manifests keyed by repository-relative path."""
+    return {
+        path.relative_to(root): path
+        for path in root.rglob("package.json")
+        if not IGNORED_DIRECTORIES.intersection(path.relative_to(root).parts)
+    }
+
+
+def lifecycle_scripts(path: Path | None) -> dict[str, object]:
+    """Read lifecycle script values from one package manifest."""
+    if path is None:
+        return {}
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot parse {path}: {error}") from error
+    scripts = document.get("scripts", {})
+    if not isinstance(scripts, dict):
+        raise ValueError(f"scripts must be an object in {path}")
+    return {
+        name: scripts[name]
+        for name in LIFECYCLE_SCRIPTS
+        if name in scripts
+    }
+
+
+def changed_lifecycle_scripts(
+    trusted_root: Path, candidate_root: Path
+) -> list[str]:
+    """Describe lifecycle hooks introduced or modified by the candidate."""
+    trusted = manifests(trusted_root)
+    candidate = manifests(candidate_root)
+    findings: list[str] = []
+    for relative, candidate_path in sorted(candidate.items()):
+        before = lifecycle_scripts(trusted.get(relative))
+        after = lifecycle_scripts(candidate_path)
+        for name, value in sorted(after.items()):
+            if before.get(name) != value:
+                action = "introduced" if name not in before else "modified"
+                findings.append(f"{relative}: {action} scripts.{name}")
+    return findings
+
+
+def main() -> int:
+    """Validate candidate manifests against the trusted base."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--trusted-root", type=Path, required=True)
+    parser.add_argument("--candidate-root", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        findings = changed_lifecycle_scripts(
+            args.trusted_root.resolve(), args.candidate_root.resolve()
+        )
+    except ValueError as error:
+        print(f"package lifecycle validation failed: {error}", file=sys.stderr)
+        return 1
+    if findings:
+        print(
+            "Candidate changes package-manager lifecycle hooks. "
+            "These hooks execute automatically during dependency operations "
+            "and require explicit security review:",
+            file=sys.stderr,
+        )
+        for finding in findings:
+            print(f"- {finding}", file=sys.stderr)
+        return 1
+    print("Package lifecycle hooks are unchanged")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dependency_security.py
+++ b/tests/test_dependency_security.py
@@ -11,6 +11,9 @@ import yaml
 ROOT = Path(__file__).parent.parent
 DEPENDABOT = ROOT / ".github" / "dependabot.yml"
 DEPENDENCY_WORKFLOW = ROOT / ".github" / "workflows" / "dependency-security.yml"
+TRUSTED_EVIDENCE_WORKFLOW = (
+    ROOT / ".github" / "workflows" / "trusted-evidence-validation.yml")
+LIFECYCLE_VALIDATOR = ROOT / "scripts" / "validate-package-lifecycle.py"
 PATTERN_VALIDATION_WORKFLOW = (
     ROOT / ".github" / "workflows" / "pattern-validation.yml")
 DOCKER_COMPATIBILITY_WORKFLOW = (
@@ -83,6 +86,26 @@ def test_dependabot_covers_all_dependency_manifest_directories():
         if "node_modules" not in path.parts
     }
     assert discovered_npm == NPM_DIRECTORIES
+
+
+def test_trusted_validation_rejects_package_lifecycle_hook_changes():
+    """Fork content must be inspected by trusted code before acceptance."""
+    workflow = TRUSTED_EVIDENCE_WORKFLOW.read_text(encoding="utf-8")
+    validator = LIFECYCLE_VALIDATOR.read_text(encoding="utf-8")
+
+    assert "trusted/scripts/validate-package-lifecycle.py" in workflow
+    assert "--trusted-root trusted" in workflow
+    assert "--candidate-root candidate" in workflow
+    assert "steps.package-lifecycle.outcome != 'success'" in workflow
+    for hook in (
+        "preinstall",
+        "install",
+        "postinstall",
+        "prepare",
+        "prepublish",
+        "prepublishOnly",
+    ):
+        assert f'"{hook}"' in validator
 
 
 def test_dependabot_groups_compatible_updates_without_grouping_majors():

--- a/tests/test_package_lifecycle_policy.py
+++ b/tests/test_package_lifecycle_policy.py
@@ -1,0 +1,74 @@
+"""Tests for the package-manager lifecycle-hook policy."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).parent.parent
+SCRIPT = ROOT / "scripts" / "validate-package-lifecycle.py"
+SPEC = importlib.util.spec_from_file_location("lifecycle_policy", SCRIPT)
+POLICY = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(POLICY)
+
+
+def write_manifest(root, scripts=None, relative="package.json"):
+    """Write one minimal package manifest."""
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"name": "example", "scripts": scripts or {}}),
+        encoding="utf-8",
+    )
+
+
+def test_rejects_lifecycle_hook_in_new_manifest(tmp_path):
+    """A new package must not introduce automatic install execution."""
+    trusted = tmp_path / "trusted"
+    candidate = tmp_path / "candidate"
+    trusted.mkdir()
+    candidate.mkdir()
+    write_manifest(candidate, {"preinstall": "echo RCE_OK"})
+
+    assert POLICY.changed_lifecycle_scripts(trusted, candidate) == [
+        "package.json: introduced scripts.preinstall"
+    ]
+
+
+def test_rejects_modified_existing_lifecycle_hook(tmp_path):
+    """A candidate must not replace an established lifecycle command."""
+    trusted = tmp_path / "trusted"
+    candidate = tmp_path / "candidate"
+    trusted.mkdir()
+    candidate.mkdir()
+    write_manifest(trusted, {"prepare": "trusted-command"}, "app/package.json")
+    write_manifest(candidate, {"prepare": "candidate-command"}, "app/package.json")
+
+    assert POLICY.changed_lifecycle_scripts(trusted, candidate) == [
+        "app/package.json: modified scripts.prepare"
+    ]
+
+
+def test_allows_ordinary_script_and_dependency_changes(tmp_path):
+    """Non-lifecycle package changes remain eligible for normal review."""
+    trusted = tmp_path / "trusted"
+    candidate = tmp_path / "candidate"
+    trusted.mkdir()
+    candidate.mkdir()
+    write_manifest(trusted, {"test": "pytest"})
+    write_manifest(candidate, {"test": "pytest -q", "lint": "ruff check ."})
+
+    assert POLICY.changed_lifecycle_scripts(trusted, candidate) == []
+
+
+def test_allows_removing_a_lifecycle_hook(tmp_path):
+    """Removing automatic execution is safe and must not be blocked."""
+    trusted = tmp_path / "trusted"
+    candidate = tmp_path / "candidate"
+    trusted.mkdir()
+    candidate.mkdir()
+    write_manifest(trusted, {"postinstall": "legacy-command"})
+    write_manifest(candidate, {})
+
+    assert POLICY.changed_lifecycle_scripts(trusted, candidate) == []


### PR DESCRIPTION
## Summary
- reject introduced or modified npm lifecycle hooks using trusted base-branch code
- keep candidate repositories inert during `pull_request_target` validation
- add regression coverage for new, modified, removed, and ordinary package scripts

## Security context
PR #89 attempted to add a `preinstall` RCE probe under a misleading dependency-maintenance title. The trusted workflow did not execute it, but previously did not reject it either.

## Validation
- `python3.14 -m pytest -q`
- 94 focused dependency/workflow tests
- validator rejects PR #89 at commit `f04af9a18393495c93ef78aa24f4528ee7869c65`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to detect newly introduced or modified package lifecycle scripts.
  * Trusted evidence checks now fail when unsafe lifecycle hook changes are detected.

* **Tests**
  * Added coverage for new, modified, removed, and unrelated package script changes.
  * Added regression checks confirming lifecycle validation is integrated into trusted validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->