### PR TITLE
chore(beads): ignore embedded-Dolt local db dirs

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -5,6 +5,12 @@
 *.db-wal
 *.db-shm
 
+# Embedded Dolt backend local database state (bd >= 1.0)
+# Per-machine database working directory and local backups; never commit.
+# The shared representation is the tracked issues.jsonl.
+embeddeddolt/
+backup/
+
 # Daemon runtime files
 daemon.lock
 daemon.log


### PR DESCRIPTION
## What

Add `embeddeddolt/` and `backup/` to `.beads/.gitignore`.

## Why

bd >= 1.0 uses an embedded Dolt backend that materializes its local database
under `.beads/embeddeddolt/` (plus local `.beads/backup/`). The existing
`.beads/.gitignore` ignores `*.db` and daemon runtime files but not these
directories, so they show up as untracked and a stray `git add .` could commit
the entire per-machine database. The shared, tracked representation is
`.beads/issues.jsonl` — these dirs are local-only state and should never be
committed.

## Notes

- Positive ignore patterns only (no negation), per the existing NOTE in the file.
- Not a trust-root file, so no `APPROVE TRUST ROOT` sign-off needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)